### PR TITLE
fix install command to allow for current directory path to have spaces in it

### DIFF
--- a/tools/install.cmd
+++ b/tools/install.cmd
@@ -1,5 +1,5 @@
 @echo off
 
-%SystemRoot%\Microsoft.NET\Framework64\v4.0.30319\regasm.exe /nologo /codebase %~dp0AudioBand.dll
+%SystemRoot%\Microsoft.NET\Framework64\v4.0.30319\regasm.exe /nologo /codebase "%~dp0AudioBand.dll"
 
 pause


### PR DESCRIPTION
I used the online GitHub editor so not sure why it changed the last line too but basically I was running this from a path with spaces in it which cmd doesn't like without quotes.