### PR TITLE
Add more async loading and fix custom labels not saving properly

### DIFF
--- a/src/AudioBand/ViewModels/AudioSourceSettingVM.cs
+++ b/src/AudioBand/ViewModels/AudioSourceSettingVM.cs
@@ -93,7 +93,7 @@ namespace AudioBand.ViewModels
             ApplyChanges();
         }
 
-        public void UpdateValue()
+        public void ValueChanged()
         {
             Model.Value = _settingInfo.GetValue();
         }

--- a/src/AudioBand/ViewModels/AudioSourceSettingsVM.cs
+++ b/src/AudioBand/ViewModels/AudioSourceSettingsVM.cs
@@ -24,7 +24,7 @@ namespace AudioBand.ViewModels
 
         private void AudioSourceOnPropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)
         {
-            Settings.FirstOrDefault(s => s.PropertyName == propertyChangedEventArgs.PropertyName)?.UpdateValue();
+            Settings.FirstOrDefault(s => s.PropertyName == propertyChangedEventArgs.PropertyName)?.ValueChanged();
         }
 
         private List<AudioSourceSettingVM> CreateSettingViewModels(AudioSourceSettings existingSettings, IAudioSource source)

--- a/src/AudioBand/ViewModels/CustomLabelsVM.cs
+++ b/src/AudioBand/ViewModels/CustomLabelsVM.cs
@@ -61,7 +61,6 @@ namespace AudioBand.ViewModels
 
         protected override void OnBeginEdit()
         {
-            base.OnBeginEdit();
             _added.Clear();
             _removed.Clear();
 
@@ -91,6 +90,17 @@ namespace AudioBand.ViewModels
             foreach (var customLabelVm in CustomLabels)
             {
                 customLabelVm.CancelEdit();
+            }
+        }
+
+        protected override void OnEndEdit()
+        {
+            _added.Clear();
+            _removed.Clear();
+
+            foreach (var customLabelVm in CustomLabels)
+            {
+                customLabelVm.EndEdit();
             }
         }
     }

--- a/src/AudioBand/Views/Wpf/SettingsWindow.xaml.cs
+++ b/src/AudioBand/Views/Wpf/SettingsWindow.xaml.cs
@@ -28,7 +28,6 @@ namespace AudioBand.Views.Wpf
             InitializeComponent();
             DataContext = _vm = vm;
             vm.CustomLabelsVM.DialogService = new DialogService(this);
-            vm.BeginEdit();
         }
 
 


### PR DESCRIPTION
- Split viewmodel loading into async stages
- Fix custom labels not calling `OnEditEdit()` fixes #51, fixes #50 