### PR TITLE
Fix new access token not being set properly

### DIFF
--- a/src/SpotifyAudioSource/SpotifyControls.cs
+++ b/src/SpotifyAudioSource/SpotifyControls.cs
@@ -20,8 +20,8 @@ namespace SpotifyAudioSource
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         public static extern IntPtr SendMessage(IntPtr hWnd, int msg, int wParam, IntPtr lParam);
 
+        public const string SpotifyPausedWindowTitle = "Spotify";
         private const int WM_APPCOMMAND = 0x0319;
-        private const string SpotifyPausedWindowTitle = "Spotify";
         private const string SpotifyWindowClassName = "Chrome_WidgetWin_0"; // Last checked spotify version 1.0.88.353
         private IntPtr _spotifyHwnd;
 


### PR DESCRIPTION
Made changes so that when new access token is received, it creates a new Spotify api object. Setting the new access token in the existing instance was not working and Spotify was responding with a 401.