### PR TITLE
Add ratings support to IAudioSource

### DIFF
--- a/src/AudioBand.AudioSource/AudioBand.AudioSource.csproj
+++ b/src/AudioBand.AudioSource/AudioBand.AudioSource.csproj
@@ -45,11 +45,13 @@
     <Compile Include="AudioSourceSettingAttribute.cs" />
     <Compile Include="IAudioSource.cs" />
     <Compile Include="IAudioSourceLogger.cs" />
+    <Compile Include="ISupportsRatings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SettingChangedEventArgs.cs" />
     <Compile Include="SettingOptions.cs" />
     <Compile Include="SettingValidationResult.cs" />
     <Compile Include="TrackInfoChangedEventArgs.cs" />
+    <Compile Include="TrackRating.cs" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json">

--- a/src/AudioBand.AudioSource/ISupportsRatings.cs
+++ b/src/AudioBand.AudioSource/ISupportsRatings.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace AudioBand.AudioSource
+{
+    /// <summary>
+    /// Indicates that this audio source supports ratings on tracks.
+    /// </summary>
+    public interface ISupportsRatings
+    {
+        /// <summary>
+        /// Occurs when the the track's rating has changed.
+        /// </summary>
+        event EventHandler<TrackRating> TrackRatingChanged;
+
+        /// <summary>
+        /// Called when a new rating is being set.
+        /// </summary>
+        /// <param name="newRating">The new rating of the track</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous set rating operation.</returns>
+        Task SetTrackRatingAsync(TrackRating newRating);
+    }
+}

--- a/src/AudioBand.AudioSource/TrackRating.cs
+++ b/src/AudioBand.AudioSource/TrackRating.cs
@@ -1,0 +1,23 @@
+﻿namespace AudioBand.AudioSource
+{
+    /// <summary>
+    /// Options for the rating of a track.
+    /// </summary>
+    public enum TrackRating
+    {
+        /// <summary>
+        /// No rating.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The track has a positive rating.
+        /// </summary>
+        Positive,
+
+        /// <summary>
+        /// The song has a negative rating.
+        /// </summary>
+        Negative
+    }
+}

--- a/src/AudioBand.ServiceContracts/IAudioSourceHost.cs
+++ b/src/AudioBand.ServiceContracts/IAudioSourceHost.cs
@@ -91,6 +91,14 @@ namespace AudioBand.ServiceContracts
         Task SetPlaybackProgress(TimeSpan progress);
 
         /// <summary>
+        /// Contract method for <see cref="ISupportsRatings.SetTrackRatingAsync(TrackRating)"/>
+        /// </summary>
+        /// <param name="rating"></param>
+        /// <returns></returns>
+        [OperationContract]
+        Task SetRatingAsync(TrackRating rating);
+
+        /// <summary>
         /// Update the audio source setting with a new value.
         /// </summary>
         /// <param name="settingName">Setting name.</param>

--- a/src/AudioBand.ServiceContracts/IAudioSourceHostCallback.cs
+++ b/src/AudioBand.ServiceContracts/IAudioSourceHostCallback.cs
@@ -45,5 +45,12 @@ namespace AudioBand.ServiceContracts
         /// <param name="volume">The new volume.</param>
         [OperationContract(IsOneWay = true)]
         void VolumeChanged(float volume);
+
+        /// <summary>
+        /// Contract method for <see cref="ISupportsRatings.TrackRatingChanged"/>.
+        /// </summary>
+        /// <param name="rating"></param>
+        [OperationContract(IsOneWay = true)]
+        void TrackRatingChanged(TrackRating rating);
     }
 }

--- a/src/AudioBand/AudioSource/AudioSourceHostCallback.cs
+++ b/src/AudioBand/AudioSource/AudioSourceHostCallback.cs
@@ -40,6 +40,11 @@ namespace AudioBand.AudioSource
         /// </summary>
         public event EventHandler<float> VolumeChanged;
 
+        /// <summary>
+        /// Occurs when <see cref="IAudioSourceHostCallback.TrackRatingChanged(TrackRating)"/> is called.
+        /// </summary>
+        public event EventHandler<TrackRating> TrackRatingChanged;
+
         /// <inheritdoc/>
         void IAudioSourceHostCallback.VolumeChanged(float volume)
         {
@@ -74,6 +79,12 @@ namespace AudioBand.AudioSource
         void IAudioSourceHostCallback.TrackProgressChanged(TimeSpan progress)
         {
             TrackProgressChanged?.Invoke(this, progress);
+        }
+
+        /// <inheritdoc/>
+        void IAudioSourceHostCallback.TrackRatingChanged(TrackRating rating)
+        {
+            TrackRatingChanged?.Invoke(this, rating);
         }
     }
 }

--- a/src/AudioSourceHost/AudioSourceHostService.cs
+++ b/src/AudioSourceHost/AudioSourceHostService.cs
@@ -30,6 +30,11 @@ namespace AudioSourceHost
             _audioSource.TrackProgressChanged += AudioSourceOnTrackProgressChanged;
             _audioSource.VolumeChanged += AudioSourceOnVolumeChanged;
 
+            if (_audioSource is ISupportsRatings supportRatings)
+            {
+                supportRatings.TrackRatingChanged += AudioSourceOnRatingChanged;
+            }
+
             _audioSourceSettingsList = _audioSource.GetSettings();
             foreach (AudioSourceSetting setting in _audioSourceSettingsList)
             {
@@ -160,6 +165,12 @@ namespace AudioSourceHost
             await _audioSource.SetPlaybackProgress(progress);
         }
 
+        public async Task SetRatingAsync(TrackRating rating)
+        {
+            var supportsRatings = _audioSource as ISupportsRatings;
+            await supportsRatings?.SetTrackRatingAsync(rating);
+        }
+
         public void OpenCallbackChannel()
         {
             Callback = OperationContext.Current.GetCallbackChannel<IAudioSourceHostCallback>();
@@ -261,6 +272,18 @@ namespace AudioSourceHost
             try
             {
                 Callback.VolumeChanged(e);
+            }
+            catch (Exception ex)
+            {
+                HandleException(ex);
+            }
+        }
+
+        private void AudioSourceOnRatingChanged(object sender, TrackRating e)
+        {
+            try
+            {
+                Callback.TrackRatingChanged(e);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Adds an interface `ISupportsRatings` which provides support for track ratings (like, dislike)