### PR TITLE
Add repeat mode support

### DIFF
--- a/src/AudioBand.AudioSource/AudioBand.AudioSource.csproj
+++ b/src/AudioBand.AudioSource/AudioBand.AudioSource.csproj
@@ -47,6 +47,7 @@
     <Compile Include="IAudioSourceLogger.cs" />
     <Compile Include="ISupportsRatings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RepeatMode.cs" />
     <Compile Include="SettingChangedEventArgs.cs" />
     <Compile Include="SettingOptions.cs" />
     <Compile Include="TrackInfoChangedEventArgs.cs" />

--- a/src/AudioBand.AudioSource/IAudioSource.cs
+++ b/src/AudioBand.AudioSource/IAudioSource.cs
@@ -46,6 +46,11 @@ namespace AudioBand.AudioSource
         event EventHandler<bool> ShuffleChanged;
 
         /// <summary>
+        /// Occurs when the repeat mode changes.
+        /// </summary>
+        event EventHandler<RepeatMode> RepeatModeChanged;
+
+        /// <summary>
         /// Gets the name of the audio source.
         /// </summary>
         /// <value>The name of the audio source.</value>
@@ -110,8 +115,15 @@ namespace AudioBand.AudioSource
         /// <summary>
         /// Called when there is a request to change the shuffle state.
         /// </summary>
-        /// <param name="shuffleOn">True if shuffle should be on; False otherwise.</param>
+        /// <param name="shuffleOn">The new shuffle state, <see langword="true"/> if shuffle should be on; <see langword="false"/> otherwise.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous set shuffle operation.</returns>
         Task SetShuffleAsync(bool shuffleOn);
+
+        /// <summary>
+        /// Called when there is a request to change the repeat mode.
+        /// </summary>
+        /// <param name="newRepeatMode">The new <see cref="RepeatMode"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous set repeat mode operation.</returns>
+        Task SetRepeatMode(RepeatMode newRepeatMode);
     }
 }

--- a/src/AudioBand.AudioSource/RepeatMode.cs
+++ b/src/AudioBand.AudioSource/RepeatMode.cs
@@ -1,0 +1,23 @@
+﻿namespace AudioBand.AudioSource
+{
+    /// <summary>
+    /// Specifies the repeat mode of the audio source.
+    /// </summary>
+    public enum RepeatMode
+    {
+        /// <summary>
+        /// No repeat.
+        /// </summary>
+        Off,
+
+        /// <summary>
+        /// Repeat the current context.
+        /// </summary>
+        RepeatContext,
+
+        /// <summary>
+        /// Repeat the current track.
+        /// </summary>
+        RepeatTrack,
+    }
+}

--- a/src/AudioBand/AudioSource/AudioSourceProxy.cs
+++ b/src/AudioBand/AudioSource/AudioSourceProxy.cs
@@ -63,7 +63,12 @@ namespace AudioBand.AudioSource
 
         /// <inheritdoc/>
         public event EventHandler<float> VolumeChanged;
+
+        /// <inheritdoc/>
         public event EventHandler<bool> ShuffleChanged;
+
+        /// <inheritdoc/>
+        public event EventHandler<RepeatMode> RepeatModeChanged;
 
         /// <inheritdoc/>
         public string Name
@@ -246,6 +251,17 @@ namespace AudioBand.AudioSource
         }
 
         /// <inheritdoc/>
+        public async Task SetRepeatMode(RepeatMode newRepeatMode)
+        {
+            if (!IsActivated)
+            {
+                return;
+            }
+
+            await CallWrapperAsync(_wrapper.SetRepeatMode, newRepeatMode);
+        }
+
+        /// <inheritdoc/>
         public Type GetSettingType(string settingName)
         {
             return _wrapper.GetSettingType(settingName);
@@ -308,6 +324,7 @@ namespace AudioBand.AudioSource
             _wrapper.TrackProgressChanged += new MarshaledEventHandler<TimeSpan>(e => TrackProgressChanged?.Invoke(this, e)).Handler;
             _wrapper.VolumeChanged += new MarshaledEventHandler<float>(e => VolumeChanged?.Invoke(this, e)).Handler;
             _wrapper.ShuffleChanged += new MarshaledEventHandler<bool>(e => ShuffleChanged?.Invoke(this, e)).Handler;
+            _wrapper.RepeatModeChanged += new MarshaledEventHandler<RepeatMode>(e => RepeatModeChanged?.Invoke(this, e)).Handler;
 
             LoadAudioSourceSettings();
         }

--- a/src/AudioSourceHost/AudioSourceWrapper.cs
+++ b/src/AudioSourceHost/AudioSourceWrapper.cs
@@ -41,6 +41,8 @@ namespace AudioSourceHost
 
         public event EventHandler<bool> ShuffleChanged;
 
+        public event EventHandler<RepeatMode> RepeatModeChanged;
+
         public string Name => _audioSource.Name;
 
         public List<AudioSourceSettingAttribute> Settings => _audioSourceSettingsList.Select(s => s.Attribute).ToList();
@@ -90,6 +92,11 @@ namespace AudioSourceHost
             StartTask(_audioSource.SetShuffleAsync, shuffle, tcs);
         }
 
+        public void SetRepeatMode(RepeatMode repeatMode, MarshaledTaskCompletionSource tcs)
+        {
+            StartTask(_audioSource.SetRepeatMode, repeatMode, tcs);
+        }
+
         public bool Initialize(string audioSourceDirectory)
         {
             try
@@ -106,6 +113,7 @@ namespace AudioSourceHost
                 _audioSource.TrackProgressChanged += (o, e) => TrackProgressChanged?.Invoke(this, e);
                 _audioSource.VolumeChanged += (o, e) => VolumeChanged?.Invoke(this, e);
                 _audioSource.ShuffleChanged += (o, e) => ShuffleChanged?.Invoke(this, e);
+                _audioSource.RepeatModeChanged += (o, e) => RepeatModeChanged?.Invoke(this, e);
 
                 _audioSourceSettingsList = _audioSource.GetSettings();
                 foreach (AudioSourceSetting setting in _audioSourceSettingsList)

--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -58,6 +58,8 @@ namespace SpotifyAudioSource
 
         public event EventHandler<bool> ShuffleChanged;
 
+        public event EventHandler<RepeatMode> RepeatModeChanged;
+
         public string Name { get; } = "Spotify";
 
         public IAudioSourceLogger Logger { get; set; }
@@ -267,6 +269,41 @@ namespace SpotifyAudioSource
         public async Task SetShuffleAsync(bool shuffleOn)
         {
             await _spotifyApi.SetShuffleAsync(shuffleOn);
+        }
+
+        public async Task SetRepeatMode(RepeatMode newRepeatMode)
+        {
+            await _spotifyApi.SetRepeatModeAsync(ToRepeatState(newRepeatMode));
+        }
+
+        private static RepeatMode ToRepeatMode(RepeatState state)
+        {
+            switch (state)
+            {
+                case RepeatState.Context:
+                    return RepeatMode.RepeatContext;
+                case RepeatState.Off:
+                    return RepeatMode.Off;
+                case RepeatState.Track:
+                    return RepeatMode.RepeatTrack;
+                default:
+                    throw new InvalidOperationException($"No case for {state}");
+            }
+        }
+
+        private static RepeatState ToRepeatState(RepeatMode mode)
+        {
+            switch (mode)
+            {
+                case RepeatMode.Off:
+                    return RepeatState.Off;
+                case RepeatMode.RepeatContext:
+                    return RepeatState.Context;
+                case RepeatMode.RepeatTrack:
+                    return RepeatState.Track;
+                default:
+                    throw new InvalidOperationException($"No case for {mode}");
+            }
         }
 
         private void Authorize()

--- a/src/iTunesAudioSource/ITunesControls.cs
+++ b/src/iTunesAudioSource/ITunesControls.cs
@@ -55,6 +55,19 @@ namespace iTunesAudioSource
             }
         }
 
+        public ITPlaylistRepeatMode RepeatMode
+        {
+            get
+            {
+                return _itunesApp.CurrentPlaylist.SongRepeat;
+            }
+
+            set
+            {
+                _itunesApp.CurrentPlaylist.SongRepeat = value;
+            }
+        }
+
         /// <summary>
         /// Gets or sets the volume from [0, 100]
         /// </summary>


### PR DESCRIPTION
Method `SetRepeatMode` added to `IAudioSource` because it can be reasonably assumed that all audio sources will support it.

- Adds 3 repeat modes: None, Context, Track
- Add support in itunes and music bee. Spotify later
- No UI support yet