### PR TITLE
Spotify audio source updates

### DIFF
--- a/src/AudioBand.Test/AudioBand.Test.csproj
+++ b/src/AudioBand.Test/AudioBand.Test.csproj
@@ -53,7 +53,7 @@
       <HintPath>..\packages\MSTest.TestFramework.1.4.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.10.0\lib\net45\Moq.dll</HintPath>
+      <HintPath>..\packages\Moq.4.10.1\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -63,7 +63,7 @@
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>

--- a/src/AudioBand.Test/packages.config
+++ b/src/AudioBand.Test/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net461" />
-  <package id="Moq" version="4.10.0" targetFramework="net461" />
+  <package id="Moq" version="4.10.1" targetFramework="net461" />
   <package id="MSTest.TestAdapter" version="1.4.0" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="1.4.0" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/src/AudioBand/AudioBand.csproj
+++ b/src/AudioBand/AudioBand.csproj
@@ -70,8 +70,8 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Svg, Version=2.2.1.39233, Culture=neutral, PublicKeyToken=12a0bac221edeae2, processorArchitecture=MSIL">
-      <HintPath>..\packages\Svg.2.3.0\lib\net35\Svg.dll</HintPath>
+    <Reference Include="Svg, Version=2.4.1.756, Culture=neutral, PublicKeyToken=12a0bac221edeae2, processorArchitecture=MSIL">
+      <HintPath>..\packages\Svg.2.4.1\lib\Svg.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/AudioBand/MainControl.cs
+++ b/src/AudioBand/MainControl.cs
@@ -98,6 +98,14 @@ namespace AudioBand
         {
             base.OnClose();
             _appSettings.Save();
+            try
+            {
+                _currentAudioSource?.DeactivateAsync();
+            }
+            catch (Exception)
+            {
+                // ignore
+            }
         }
 
         private async Task InitializeAsync()

--- a/src/AudioBand/packages.config
+++ b/src/AudioBand/packages.config
@@ -11,7 +11,7 @@
   <package id="Nett" version="0.10.1" targetFramework="net461" />
   <package id="NLog" version="4.5.11" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net461" developmentDependency="true" />
-  <package id="Svg" version="2.3.0" targetFramework="net461" />
+  <package id="Svg" version="2.4.1" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
   <package id="WriteableBitmapEx" version="1.5.1.0" targetFramework="net461" />
 </packages>

--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -554,7 +554,11 @@ namespace SpotifyAudioSource
             }
             finally
             {
-                _checkSpotifyTimer.Enabled = true;
+                // check again in case
+                if (_isActive)
+                {
+                    _checkSpotifyTimer.Enabled = true;
+                }
             }
         }
 


### PR DESCRIPTION
Spotify audio source now polls every second to get updates and slower if paused (may remove that feature later). It should be under the rate limit for the api. Fixes #78 

Other changes
- Updated spotify audio source to properly implement the new IAudioSource features
- Fixes #87 where local tracks don't update