### PR TITLE
Change invalid enum values to return default instead of throwing

### DIFF
--- a/src/MusicBeeAudioSource/AudioSource.cs
+++ b/src/MusicBeeAudioSource/AudioSource.cs
@@ -113,7 +113,7 @@ namespace MusicBeeAudioSource
             return Task.CompletedTask;
         }
 
-        private static RepeatMode ToRepeatMode(MusicBeeIPC.RepeatMode mode)
+        private RepeatMode ToRepeatMode(MusicBeeIPC.RepeatMode mode)
         {
             switch (mode)
             {
@@ -124,11 +124,12 @@ namespace MusicBeeAudioSource
                 case MusicBeeIPC.RepeatMode.One:
                     return RepeatMode.RepeatTrack;
                 default:
-                    throw new InvalidOperationException($"No case for {mode}");
+                    Logger.Warn($"No case for {mode}");
+                    return RepeatMode.Off;
             }
         }
 
-        private static MusicBeeIPC.RepeatMode ToIpcRepeat(RepeatMode mode)
+        private MusicBeeIPC.RepeatMode ToIpcRepeat(RepeatMode mode)
         {
             switch (mode)
             {
@@ -139,7 +140,8 @@ namespace MusicBeeAudioSource
                 case RepeatMode.RepeatTrack:
                     return MusicBeeIPC.RepeatMode.One;
                 default:
-                    throw new InvalidOperationException($"No case for {mode}");
+                    Logger.Warn($"No case for {mode}");
+                    return MusicBeeIPC.RepeatMode.None;
             }
         }
 

--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -267,7 +267,7 @@ namespace SpotifyAudioSource
             await _spotifyApi.SetRepeatModeAsync(ToRepeatState(newRepeatMode));
         }
 
-        private static RepeatMode ToRepeatMode(RepeatState state)
+        private RepeatMode ToRepeatMode(RepeatState state)
         {
             switch (state)
             {
@@ -278,11 +278,12 @@ namespace SpotifyAudioSource
                 case RepeatState.Track:
                     return RepeatMode.RepeatTrack;
                 default:
-                    throw new InvalidOperationException($"No case for {state}");
+                    Logger.Warn($"No case for {state}");
+                    return RepeatMode.Off;
             }
         }
 
-        private static RepeatState ToRepeatState(RepeatMode mode)
+        private RepeatState ToRepeatState(RepeatMode mode)
         {
             switch (mode)
             {
@@ -293,7 +294,8 @@ namespace SpotifyAudioSource
                 case RepeatMode.RepeatTrack:
                     return RepeatState.Track;
                 default:
-                    throw new InvalidOperationException($"No case for {mode}");
+                    Logger.Warn("No case for {mode}");
+                    return RepeatState.Off;
             }
         }
 

--- a/src/iTunesAudioSource/AudioSource.cs
+++ b/src/iTunesAudioSource/AudioSource.cs
@@ -115,7 +115,7 @@ namespace iTunesAudioSource
             return Task.CompletedTask;
         }
 
-        private static RepeatMode ToRepeatMode(ITPlaylistRepeatMode mode)
+        private RepeatMode ToRepeatMode(ITPlaylistRepeatMode mode)
         {
             switch (mode)
             {
@@ -126,11 +126,12 @@ namespace iTunesAudioSource
                 case ITPlaylistRepeatMode.ITPlaylistRepeatModeOne:
                     return RepeatMode.RepeatTrack;
                 default:
-                    throw new InvalidOperationException($"No case for {mode}");
+                    Logger.Warn($"No case for {mode}");
+                    return RepeatMode.Off;
             }
         }
 
-        private static ITPlaylistRepeatMode ToITRepeat(RepeatMode mode)
+        private ITPlaylistRepeatMode ToITRepeat(RepeatMode mode)
         {
             switch (mode)
             {
@@ -141,7 +142,8 @@ namespace iTunesAudioSource
                 case RepeatMode.RepeatTrack:
                     return ITPlaylistRepeatMode.ITPlaylistRepeatModeOne;
                 default:
-                    throw new InvalidOperationException($"No case for {mode}");
+                    Logger.Warn($"No case for {mode}");
+                    return ITPlaylistRepeatMode.ITPlaylistRepeatModeOff;
             }
         }
 


### PR DESCRIPTION
Did not know enums could have other values than the ones defined and still be valid.