### PR TITLE
Logging update

### DIFF
--- a/src/AudioBand.Logging/AudioBand.Logging.csproj
+++ b/src/AudioBand.Logging/AudioBand.Logging.csproj
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D8E1D3E5-D0AB-43C4-8AF6-60C14C5C6843}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AudioBand.Logging</RootNamespace>
+    <AssemblyName>AudioBand.Logging</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Ben.Demystifier, Version=0.1.0.0, Culture=neutral, PublicKeyToken=a6d206e05440431a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ben.Demystifier.0.1.4\lib\net45\Ben.Demystifier.dll</HintPath>
+    </Reference>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.5.11\lib\net45\NLog.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.4.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Reflection.Metadata, Version=1.4.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.5.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AudioBandExceptionLayoutRenderer.cs" />
+    <Compile Include="AudioBandLogManager.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/AudioBand.Logging/AudioBandExceptionLayoutRenderer.cs
+++ b/src/AudioBand.Logging/AudioBandExceptionLayoutRenderer.cs
@@ -1,0 +1,23 @@
+﻿using NLog.LayoutRenderers;
+using System;
+using System.Diagnostics;
+using System.Text;
+
+namespace AudioBand.Logging
+{
+    public class AudioBandExceptionLayoutRenderer : ExceptionLayoutRenderer
+    {
+        protected override void AppendToString(StringBuilder sb, Exception ex)
+        {
+            if (ex == null)
+            {
+                return;
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("---START OF EXCEPTION---");
+            sb.AppendLine(ex.ToStringDemystified());
+            sb.AppendLine("---END OF EXCEPTION---");
+        }
+    }
+}

--- a/src/AudioBand.Logging/AudioBandLogManager.cs
+++ b/src/AudioBand.Logging/AudioBandLogManager.cs
@@ -1,0 +1,34 @@
+﻿using NLog;
+using NLog.Config;
+using NLog.LayoutRenderers;
+using System.IO;
+using System.Reflection;
+
+namespace AudioBand.Logging
+{
+    /// <summary>
+    /// Log mananger for audioband loggers
+    /// </summary>
+    public static class AudioBandLogManager
+    {
+        private static LogFactory LogFactory;
+
+        public static ILogger GetLogger(string name)
+        {
+            return LogFactory.GetLogger(name);
+        }
+
+        public static ILogger GetLogger<T>()
+        {
+            return LogFactory.GetLogger(typeof(T).FullName);
+        }
+
+        public static void Initialize()
+        {
+            LayoutRenderer.Register<AudioBandExceptionLayoutRenderer>("audioband-exception");
+            var configFileFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var config = new XmlLoggingConfiguration(Path.Combine(configFileFolder, "nlog.config"));
+            LogFactory = new LogFactory(config);
+        }
+    }
+}

--- a/src/AudioBand.Logging/AudioBandLogManager.cs
+++ b/src/AudioBand.Logging/AudioBandLogManager.cs
@@ -11,7 +11,7 @@ namespace AudioBand.Logging
     /// </summary>
     public static class AudioBandLogManager
     {
-        private static LogFactory LogFactory;
+        private static LogFactory LogFactory = new LogFactory();
 
         public static ILogger GetLogger(string name)
         {
@@ -28,7 +28,7 @@ namespace AudioBand.Logging
             LayoutRenderer.Register<AudioBandExceptionLayoutRenderer>("audioband-exception");
             var configFileFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var config = new XmlLoggingConfiguration(Path.Combine(configFileFolder, "nlog.config"));
-            LogFactory = new LogFactory(config);
+            LogFactory.Configuration = config;
         }
     }
 }

--- a/src/AudioBand.Logging/Properties/AssemblyInfo.cs
+++ b/src/AudioBand.Logging/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AudioBand.Logging")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AudioBand.Logging")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d8e1d3e5-d0ab-43c4-8af6-60c14c5c6843")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/AudioBand.Logging/packages.config
+++ b/src/AudioBand.Logging/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Ben.Demystifier" version="0.1.4" targetFramework="net461" />
+  <package id="NLog" version="4.5.11" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.4.0" targetFramework="net461" />
+  <package id="System.Reflection.Metadata" version="1.5.0" targetFramework="net461" />
+</packages>

--- a/src/AudioBand.sln
+++ b/src/AudioBand.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MusicBeeAudioSource", "Musi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioSourceHost", "AudioSourceHost\AudioSourceHost.csproj", "{D3F92C3E-E546-4A6B-ADA2-FACD95E229F7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioBand.Logging", "AudioBand.Logging\AudioBand.Logging.csproj", "{D8E1D3E5-D0AB-43C4-8AF6-60C14C5C6843}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{D3F92C3E-E546-4A6B-ADA2-FACD95E229F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D3F92C3E-E546-4A6B-ADA2-FACD95E229F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D3F92C3E-E546-4A6B-ADA2-FACD95E229F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8E1D3E5-D0AB-43C4-8AF6-60C14C5C6843}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8E1D3E5-D0AB-43C4-8AF6-60C14C5C6843}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8E1D3E5-D0AB-43C4-8AF6-60C14C5C6843}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8E1D3E5-D0AB-43C4-8AF6-60C14C5C6843}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AudioBand/AudioBand.csproj
+++ b/src/AudioBand/AudioBand.csproj
@@ -62,9 +62,7 @@
     <Reference Include="Nett, Version=0.10.0.0, Culture=neutral, PublicKeyToken=605dcfe7a1d3365b, processorArchitecture=MSIL">
       <HintPath>..\packages\Nett.0.10.1\lib\Net40\Nett.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.11\lib\net45\NLog.dll</HintPath>
-    </Reference>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="Svg, Version=2.4.1.756, Culture=neutral, PublicKeyToken=12a0bac221edeae2, processorArchitecture=MSIL">
@@ -306,6 +304,10 @@
     <ProjectReference Include="..\AudioBand.AudioSource\AudioBand.AudioSource.csproj">
       <Project>{30f2bfea-788a-494d-88e7-f2070528ebea}</Project>
       <Name>AudioBand.AudioSource</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\AudioBand.Logging\AudioBand.Logging.csproj">
+      <Project>{d8e1d3e5-d0ab-43c4-8af6-60c14c5c6843}</Project>
+      <Name>AudioBand.Logging</Name>
     </ProjectReference>
     <ProjectReference Include="..\AudioSourceHost\AudioSourceHost.csproj">
       <Project>{D3F92C3E-E546-4A6B-ADA2-FACD95E229F7}</Project>

--- a/src/AudioBand/AudioSource/AudioSourceManager.cs
+++ b/src/AudioBand/AudioSource/AudioSourceManager.cs
@@ -28,7 +28,7 @@ namespace AudioBand.AudioSource
         /// </summary>
         public void LoadAudioSources()
         {
-            Logger.Debug("Loading audio sources");
+            Logger.Debug("Loading audio sources as {path}", PluginFolderPath);
             foreach (var dir in Directory.EnumerateDirectories(PluginFolderPath))
             {
                 try
@@ -38,7 +38,7 @@ namespace AudioBand.AudioSource
                 }
                 catch (Exception e)
                 {
-                    Logger.Error(e, $"Error creating proxy for {dir}");
+                    Logger.Error(e, "Error creating proxy for audiosource in {path}", dir);
                 }
             }
         }

--- a/src/AudioBand/AudioSource/AudioSourceManager.cs
+++ b/src/AudioBand/AudioSource/AudioSourceManager.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
+using AudioBand.Logging;
 using NLog;
 
 namespace AudioBand.AudioSource
@@ -16,7 +14,7 @@ namespace AudioBand.AudioSource
     {
         private const string PluginFolderName = "AudioSources";
         private static readonly string PluginFolderPath = Path.Combine(DirectoryHelper.BaseDirectory, PluginFolderName);
-        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+        private static readonly ILogger Logger = AudioBandLogManager.GetLogger<AudioSourceManager>();
         private static readonly object _audioSourcesLock = new object();
         private readonly List<AudioSourceProxy> _uninitializedProxies = new List<AudioSourceProxy>();
 

--- a/src/AudioBand/AudioSource/AudioSourceProxy.cs
+++ b/src/AudioBand/AudioSource/AudioSourceProxy.cs
@@ -128,7 +128,7 @@ namespace AudioBand.AudioSource
                 }
                 catch (Exception e)
                 {
-                    _logger.Error(e, "Error trying to get setting.");
+                    _logger.Error(e, "Error trying to get setting {name}", settingName);
                     throw;
                 }
             }
@@ -142,7 +142,7 @@ namespace AudioBand.AudioSource
                 }
                 catch (Exception e)
                 {
-                    _logger.Error(e, "Error tring to update setting.");
+                    _logger.Error(e, "Error tring to update setting {name}", settingName);
                     throw;
                 }
             }

--- a/src/AudioBand/AudioSource/AudioSourceProxy.cs
+++ b/src/AudioBand/AudioSource/AudioSourceProxy.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using AudioBand.Logging;
 using AudioSourceHost;
 using NLog;
 
@@ -32,7 +32,7 @@ namespace AudioBand.AudioSource
         {
             _directory = directory;
             var directoryName = new DirectoryInfo(directory).Name;
-            _logger = LogManager.GetLogger($"AudioSourceProxy({directoryName})");
+            _logger = AudioBandLogManager.GetLogger($"AudioSourceProxy({directoryName})");
 
             AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve;
 

--- a/src/AudioBand/Deskband.cs
+++ b/src/AudioBand/Deskband.cs
@@ -1,5 +1,7 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using AudioBand.Logging;
 using CSDeskBand;
 
 namespace AudioBand
@@ -19,6 +21,8 @@ namespace AudioBand
         /// </summary>
         public Deskband()
         {
+            AudioBandLogManager.Initialize();
+            AppDomain.CurrentDomain.UnhandledException += (sender, args) => AudioBandLogManager.GetLogger("AudioBand").Error((Exception)args.ExceptionObject, "Unhandled Exception");
             _mainControl = new MainControl(Options, TaskbarInfo);
         }
 

--- a/src/AudioBand/MainControl.Bindings.cs
+++ b/src/AudioBand/MainControl.Bindings.cs
@@ -92,7 +92,7 @@ namespace AudioBand
 
             if (control == null)
             {
-                Logger.Warn("Tried removing label but the control was not found");
+                Logger.Warn("Tried removing label but the control was not found. Label: {@label}", customLabel);
                 return;
             }
 

--- a/src/AudioBand/MainControl.EventHandlers.cs
+++ b/src/AudioBand/MainControl.EventHandlers.cs
@@ -13,8 +13,6 @@ namespace AudioBand
     {
         private static readonly object _audiosourceListLock = new object();
 
-        #region Winforms event handlers
-
         private void AlbumArtOnMouseLeave(object o, EventArgs args)
         {
             AlbumArtPopup.Hide(this);
@@ -47,10 +45,6 @@ namespace AudioBand
             await (_currentAudioSource?.NextTrackAsync() ?? Task.CompletedTask);
         }
 
-        #endregion
-
-        #region Deskband context menu event handlers
-
         private void SettingsMenuItemOnClicked(object sender, EventArgs eventArgs)
         {
             OpenSettingsWindow();
@@ -61,10 +55,6 @@ namespace AudioBand
             await HandleAudioSourceContextMenuItemClick(sender as DeskBandMenuAction).ConfigureAwait(false);
         }
 
-        #endregion
-
-        #region Audio source event handlers
-
         private async void AudioSourceOnTrackProgressChanged(object o, TimeSpan progress)
         {
             await _uiDispatcher.InvokeAsync(() => { _trackModel.TrackProgress = progress; });
@@ -72,43 +62,29 @@ namespace AudioBand
 
         private async void AudioSourceOnIsPlayingChanged(object sender, bool isPlaying)
         {
-            Logger.Debug($"Play state changed. Is playing: {isPlaying}");
+            Logger.Debug("Play state changed. Is playing: {playing}", isPlaying);
             await _uiDispatcher.InvokeAsync(() => _trackModel.IsPlaying = isPlaying);
         }
 
-        private void AudioSourceOnTrackInfoChanged(object sender, TrackInfoChangedEventArgs trackInfoChangedEventArgs)
+        private void AudioSourceOnTrackInfoChanged(object sender, TrackInfoChangedEventArgs e)
         {
-            if (trackInfoChangedEventArgs == null)
+            if (e == null)
             {
                 Logger.Error("TrackInfoChanged event arg is null");
                 return;
             }
 
-            if (trackInfoChangedEventArgs.TrackName == null)
-            {
-                trackInfoChangedEventArgs.TrackName = "";
-                Logger.Warn("Track name is null");
-            }
-
-            if (trackInfoChangedEventArgs.Artist == null)
-            {
-                trackInfoChangedEventArgs.Artist = "";
-                Logger.Warn("Artist is null");
-            }
-
-            Logger.Debug($"Track changed - Name: '{trackInfoChangedEventArgs.TrackName}', Artist: '{trackInfoChangedEventArgs.Artist}'");
+            Logger.Debug("Track changed. {track}", new { e.Artist, e.TrackName, e.Album, e.TrackLength });
 
             _uiDispatcher.InvokeAsync(() =>
             {
-                _trackModel.AlbumArt = trackInfoChangedEventArgs.AlbumArt;
-                _trackModel.Artist = trackInfoChangedEventArgs.Artist;
-                _trackModel.TrackName = trackInfoChangedEventArgs.TrackName;
-                _trackModel.TrackLength = trackInfoChangedEventArgs.TrackLength;
-                _trackModel.AlbumName = trackInfoChangedEventArgs.Album;
+                _trackModel.AlbumArt = e.AlbumArt;
+                _trackModel.Artist = e.Artist;
+                _trackModel.TrackName = e.TrackName;
+                _trackModel.TrackLength = e.TrackLength;
+                _trackModel.AlbumName = e.Album;
             });
         }
-
-        #endregion
 
         private void SettingsWindowOnSaved(object o, EventArgs eventArgs)
         {
@@ -132,7 +108,7 @@ namespace AudioBand
             }
             else
             {
-                Logger.Warn($"Action {e.Action} not supported");
+                Logger.Warn("Action {action} not supported", e.Action);
             }
         }
 

--- a/src/AudioBand/MainControl.cs
+++ b/src/AudioBand/MainControl.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms.Integration;
 using System.Windows.Threading;
 using AudioBand.AudioSource;
+using AudioBand.Logging;
 using AudioBand.Models;
 using AudioBand.Settings;
 using AudioBand.ViewModels;
@@ -14,7 +15,6 @@ using AudioBand.Views.Winforms;
 using CSDeskBand;
 using CSDeskBand.ContextMenu;
 using NLog;
-using NLog.Config;
 using SettingsWindow = AudioBand.Views.Wpf.SettingsWindow;
 using Size = System.Drawing.Size;
 
@@ -22,7 +22,7 @@ namespace AudioBand
 {
     public partial class MainControl : AudioBandControl
     {
-        private static readonly ILogger Logger = LogManager.GetLogger("Audio Band");
+        private static readonly ILogger Logger = AudioBandLogManager.GetLogger("Audio Band");
         private readonly AppSettings _appSettings = new AppSettings();
         private readonly Dispatcher _uiDispatcher;
         private AudioSourceManager _audioSourceManager;
@@ -48,11 +48,6 @@ namespace AudioBand
 
         #endregion
 
-        static MainControl()
-        {
-            AppDomain.CurrentDomain.UnhandledException += (sender, args) => LogManager.GetCurrentClassLogger().Error((Exception)args.ExceptionObject, "Unhandled Exception");
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MainControl"/> class.
         /// Entry point.
@@ -63,8 +58,6 @@ namespace AudioBand
         {
             InitializeComponent();
 
-            LogManager.ThrowExceptions = true;
-            LogManager.Configuration = new XmlLoggingConfiguration(Path.Combine(DirectoryHelper.BaseDirectory, "nlog.config"));
             _uiDispatcher = Dispatcher.CurrentDispatcher;
             Options = options;
             TaskbarInfo = info;

--- a/src/AudioBand/Models/ModelBase.cs
+++ b/src/AudioBand/Models/ModelBase.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using AudioBand.Logging;
 using NLog;
 
 namespace AudioBand.Models
@@ -15,7 +16,7 @@ namespace AudioBand.Models
         /// </summary>
         public ModelBase()
         {
-            Logger = LogManager.GetLogger(GetType().FullName);
+            Logger = AudioBandLogManager.GetLogger(GetType().FullName);
         }
 
         /// <inheritdoc cref="INotifyPropertyChanged.PropertyChanged"/>

--- a/src/AudioBand/Settings/AppSettings.cs
+++ b/src/AudioBand/Settings/AppSettings.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using AudioBand.Logging;
 using AudioBand.Models;
 using AudioBand.Settings.Migrations;
 using AudioBand.Settings.Models.V2;
@@ -25,7 +26,7 @@ namespace AudioBand.Settings
         private static readonly string CurrentVersion = "2";
         private static readonly string SettingsDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "AudioBand");
         private static readonly string SettingsFilePath = Path.Combine(SettingsDirectory, "audioband.settings");
-        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+        private static readonly ILogger Logger = AudioBandLogManager.GetLogger<AppSettings>();
         private readonly TomlSettings _tomlSettings;
         private Models.V2.Settings _settings;
 

--- a/src/AudioBand/Settings/AppSettings.cs
+++ b/src/AudioBand/Settings/AppSettings.cs
@@ -169,7 +169,7 @@ namespace AudioBand.Settings
             }
             catch (Exception e)
             {
-                Logger.Error("Error loading settings: " + e);
+                Logger.Error(e, "Error loading settings");
                 throw;
             }
         }
@@ -182,7 +182,7 @@ namespace AudioBand.Settings
             }
             catch (Exception e)
             {
-                Logger.Error(e, $"Cannot convert setting {setting} to model {typeof(TModel)}");
+                Logger.Error(e, "Cannot convert setting {name} to model of type {type}", setting, typeof(TModel));
                 throw;
             }
         }
@@ -195,7 +195,7 @@ namespace AudioBand.Settings
             }
             catch (Exception e)
             {
-                Logger.Error(e, $"Cannot model to settings {model} target: {typeof(T)}");
+                Logger.Error(e, "Cannot convert model {@model} to setting of type {type}", model, typeof(T));
                 throw;
             }
         }

--- a/src/AudioBand/Settings/Migrations/Migration.cs
+++ b/src/AudioBand/Settings/Migrations/Migration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using AudioBand.Logging;
 using NLog;
 
 namespace AudioBand.Settings.Migrations
@@ -15,7 +16,7 @@ namespace AudioBand.Settings.Migrations
             { ("0.1", "2"), new V1ToV2() }
         };
 
-        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+        private static readonly ILogger Logger = AudioBandLogManager.GetLogger(typeof(Migration).FullName);
 
         /// <summary>
         /// Migrate settings to new version.

--- a/src/AudioBand/Settings/Migrations/Migration.cs
+++ b/src/AudioBand/Settings/Migrations/Migration.cs
@@ -39,7 +39,7 @@ namespace AudioBand.Settings.Migrations
                 throw new ArgumentException($"No migration plan from {oldVersion} to {newVersion}");
             }
 
-            Logger.Debug($"Found old settings v{oldVersion}. Migrating settings using {string.Join("->", plan)}");
+            Logger.Debug("Found old settings v{old}. Migrating settings using {plan}", oldVersion, string.Join("->", plan));
 
             object settings = plan.Aggregate(oldSettings, (current, settingsMigrator) => settingsMigrator.MigrateSetting(current));
             return (TNew)settings;

--- a/src/AudioBand/ViewModels/ViewModelBase.cs
+++ b/src/AudioBand/ViewModels/ViewModelBase.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using AudioBand.Commands;
+using AudioBand.Logging;
 using AutoMapper;
 using FastMember;
 using NLog;
@@ -24,7 +25,7 @@ namespace AudioBand.ViewModels
         /// </summary>
         protected ViewModelBase()
         {
-            Logger = LogManager.GetLogger(GetType().FullName);
+            Logger = AudioBandLogManager.GetLogger(GetType().FullName);
             Accessor = TypeAccessor.Create(GetType());
 
             BeginEditCommand = new RelayCommand(o => BeginEdit());
@@ -72,7 +73,7 @@ namespace AudioBand.ViewModels
         /// <summary>
         /// Gets the logger for the view model
         /// </summary>
-        protected Logger Logger { get; }
+        protected ILogger Logger { get; }
 
         /// <summary>
         /// Gets the type accessor for this object.

--- a/src/AudioBand/ViewModels/ViewModelBase{TModel}.cs
+++ b/src/AudioBand/ViewModels/ViewModelBase{TModel}.cs
@@ -157,7 +157,7 @@ namespace AudioBand.ViewModels
             }
             catch (Exception e)
             {
-                LogManager.GetCurrentClassLogger().Debug($"Error loading image from {path}, {e}");
+                Logger.Error(e, $"Error loading image from {path}");
                 return defaultImage;
             }
         }

--- a/src/AudioBand/ViewModels/ViewModelBase{TModel}.cs
+++ b/src/AudioBand/ViewModels/ViewModelBase{TModel}.cs
@@ -105,7 +105,7 @@ namespace AudioBand.ViewModels
             base.OnCancelEdit();
             if (_backup == null)
             {
-                Logger.Warn("Backup is null. Begin edit wasn't called.");
+                Logger.Warn("Cancelling edit but backup is null. Begin edit wasn't called.");
             }
 
             _mapperConfiguration.CreateMapper().Map(_backup, Model);
@@ -120,7 +120,7 @@ namespace AudioBand.ViewModels
             base.OnEndEdit();
             if (_backup == null)
             {
-                Logger.Warn("Backup is null. Begin edit wasn't called.");
+                Logger.Warn("Ending edit but backup is null. Begin edit wasn't called.");
             }
 
             _backup = null;
@@ -157,7 +157,7 @@ namespace AudioBand.ViewModels
             }
             catch (Exception e)
             {
-                Logger.Error(e, $"Error loading image from {path}");
+                Logger.Error(e, "Error loading image from {path}", path);
                 return defaultImage;
             }
         }

--- a/src/AudioBand/Views/Winforms/AudioBandControl.cs
+++ b/src/AudioBand/Views/Winforms/AudioBandControl.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using AudioBand.Logging;
 using NLog;
 
 namespace AudioBand.Views.Winforms
@@ -15,7 +16,7 @@ namespace AudioBand.Views.Winforms
         private const double LogicalDpi = 96.0;
         private const int WmDpiChanged = 0x02E0;
         private const int WHCallWndProc = 4;
-        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+        private static readonly ILogger Logger = AudioBandLogManager.GetLogger<AudioBandControl>();
         private readonly IntPtr _hook;
         private readonly NativeMethods.CallWndProc _callback;
         private readonly IntPtr _taskBarHwnd;

--- a/src/AudioBand/Views/Wpf/TemplateSelectors/AudioSourceSettingSelector.cs
+++ b/src/AudioBand/Views/Wpf/TemplateSelectors/AudioSourceSettingSelector.cs
@@ -85,7 +85,7 @@ namespace AudioBand.Views.Wpf.TemplateSelectors
 
         private DataTemplate SelectValueTemplate(Type type, AudioSourceSettingVM setting)
         {
-            Logger.Debug($"Selecting value template for setting {setting.Name}, type {type}");
+            Logger.Debug("Selecting value template for setting {name}, type {type}", setting.Name, type);
 
             if (type == typeof(string))
             {
@@ -107,7 +107,7 @@ namespace AudioBand.Views.Wpf.TemplateSelectors
                 return UIntTemplate;
             }
 
-            throw new ArgumentException($"No matching value template for `{type}`");
+            throw new ArgumentException("No matching value template for `{type}`");
         }
 
         private DataTemplate SelectKeyTemplate(AudioSourceSettingVM setting)

--- a/src/AudioBand/Views/Wpf/TemplateSelectors/AudioSourceSettingSelector.cs
+++ b/src/AudioBand/Views/Wpf/TemplateSelectors/AudioSourceSettingSelector.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
+using AudioBand.Logging;
 using AudioBand.ViewModels;
 using NLog;
 
@@ -11,7 +12,7 @@ namespace AudioBand.Views.Wpf.TemplateSelectors
     /// </summary>
     internal class AudioSourceSettingSelector : DataTemplateSelector
     {
-        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+        private static readonly ILogger Logger = AudioBandLogManager.GetLogger<AudioSourceSettingSelector>();
 
         /// <summary>
         /// The type of template to select.

--- a/src/AudioBand/nlog.config
+++ b/src/AudioBand/nlog.config
@@ -1,8 +1,9 @@
-﻿<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+﻿<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      throwExceptions="true">
   <targets>
     <target xsi:type="File" 
             name="filetarget" 
-            layout="${longdate}|${level:uppercase=true}|${logger}|${message}${when:when=length('${exception}')>0:Inner=${newline}------Begin Exception----${newline}}${exception:format=tostring}${when:when=length('${exception}')>0:Inner=${newline}------End Exception----${newline}}"
+            layout="${longdate}|${level:uppercase=true}|${logger}|${message}${audioband-exception:format=toString}"
             maxArchiveFiles="3"
             archiveNumbering="Date"
             archiveEvery="Day"
@@ -14,7 +15,6 @@
     <target xsi:type="Null" name="null"/>
   </targets>
   <rules>
-    <logger name="CSDeskBand.*" minLevel="Trace" writeTo="null" final="true"/>
     <logger name="*" minLevel="Debug" writeTo="filetarget"/>
   </rules>
 </nlog>

--- a/src/AudioBand/packages.config
+++ b/src/AudioBand/packages.config
@@ -7,7 +7,6 @@
   <package id="MahApps.Metro" version="1.6.5" targetFramework="net461" requireReinstallation="true" />
   <package id="MahApps.Metro.IconPacks.Material" version="2.3.0" targetFramework="net461" />
   <package id="Nett" version="0.10.1" targetFramework="net461" />
-  <package id="NLog" version="4.5.11" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net461" developmentDependency="true" />
   <package id="Svg" version="2.4.1" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net47" />

--- a/src/AudioSourceHost/AudioSourceHost.csproj
+++ b/src/AudioSourceHost/AudioSourceHost.csproj
@@ -44,9 +44,7 @@
     <Reference Include="Nett, Version=0.10.0.0, Culture=neutral, PublicKeyToken=605dcfe7a1d3365b, processorArchitecture=MSIL">
       <HintPath>..\packages\Nett.0.10.1\lib\Net40\Nett.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.11\lib\net45\NLog.dll</HintPath>
-    </Reference>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
@@ -82,6 +80,10 @@
     <ProjectReference Include="..\AudioBand.AudioSource\AudioBand.AudioSource.csproj">
       <Project>{30F2BFEA-788A-494D-88E7-F2070528EBEA}</Project>
       <Name>AudioBand.AudioSource</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\AudioBand.Logging\AudioBand.Logging.csproj">
+      <Project>{d8e1d3e5-d0ab-43c4-8af6-60c14c5c6843}</Project>
+      <Name>AudioBand.Logging</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/AudioSourceHost/AudioSourceLoader.cs
+++ b/src/AudioSourceHost/AudioSourceLoader.cs
@@ -24,12 +24,12 @@ namespace AudioSourceHost
         /// <returns>A list of audiosources found in the directory.</returns>
         public static IAudioSource LoadFromDirectory(string directory)
         {
-            Logger.Debug($"Probing path `{directory}` for audio source");
+            Logger.Debug("Probing path {path} for audio source", directory);
 
             var manifestPath = Directory.GetFiles(directory, ManifestFileName, SearchOption.TopDirectoryOnly).FirstOrDefault();
             if (manifestPath == null)
             {
-                throw new FileNotFoundException("No manifest found in {directory}");
+                throw new FileNotFoundException($"No manifest found in {directory}");
             }
 
             var manifestData = Toml.ReadFile<Manifest>(manifestPath);
@@ -39,7 +39,7 @@ namespace AudioSourceHost
             }
 
             var audioSourcePath = Path.Combine(directory, manifestData.AudioSource);
-            Logger.Debug($"Loading audio source from path `{audioSourcePath}`");
+            Logger.Debug("Loading audio source from path {path}", audioSourcePath);
 
             var container = new CompositionContainer(new AssemblyCatalog(audioSourcePath));
             return container.GetExportedValue<IAudioSource>();

--- a/src/AudioSourceHost/AudioSourceLoader.cs
+++ b/src/AudioSourceHost/AudioSourceLoader.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.Composition.Hosting;
 using System.IO;
 using System.Linq;
 using AudioBand.AudioSource;
+using AudioBand.Logging;
 using Nett;
 using NLog;
 
@@ -14,7 +15,7 @@ namespace AudioSourceHost
     internal class AudioSourceLoader
     {
         private const string ManifestFileName = "AudioSource.manifest";
-        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+        private static readonly ILogger Logger = AudioBandLogManager.GetLogger<AudioSourceLoader>();
 
         /// <summary>
         /// Load audio source from a directory.

--- a/src/AudioSourceHost/AudioSourceLogger.cs
+++ b/src/AudioSourceHost/AudioSourceLogger.cs
@@ -1,4 +1,5 @@
 ﻿using AudioBand.AudioSource;
+using AudioBand.Logging;
 using NLog;
 
 namespace AudioSourceHost
@@ -9,7 +10,7 @@ namespace AudioSourceHost
 
         public AudioSourceLogger(string audiosourceName)
         {
-            _logger = LogManager.GetLogger($"AudioSource({audiosourceName})");
+            _logger = AudioBandLogManager.GetLogger($"AudioSource({audiosourceName})");
         }
 
         public void Debug(string message)

--- a/src/AudioSourceHost/AudioSourceSetting.cs
+++ b/src/AudioSourceHost/AudioSourceSetting.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using AudioBand.AudioSource;
+using AudioBand.Logging;
 using FastMember;
 using NLog;
 
@@ -11,7 +12,7 @@ namespace AudioSourceHost
     /// </summary>
     internal class AudioSourceSetting
     {
-        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+        private static readonly ILogger Logger = AudioBandLogManager.GetLogger<AudioSourceSetting>();
         private readonly ObjectAccessor _accessor;
 
         /// <summary>

--- a/src/AudioSourceHost/AudioSourceSetting.cs
+++ b/src/AudioSourceHost/AudioSourceSetting.cs
@@ -71,7 +71,7 @@ namespace AudioSourceHost
             }
             catch (Exception e)
             {
-                Logger.Error(e, $"Error occured while changing audio source settings. property: `{PropertyName}`, value: {value}");
+                Logger.Error(e, "Error occured while updating audio source settings. {info}", new { PropertyName, Value = value, SettingType });
                 throw;
             }
         }

--- a/src/AudioSourceHost/AudioSourceWrapper.cs
+++ b/src/AudioSourceHost/AudioSourceWrapper.cs
@@ -2,12 +2,10 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using AudioBand.AudioSource;
+using AudioBand.Logging;
 using NLog;
-using NLog.Config;
 
 namespace AudioSourceHost
 {
@@ -23,8 +21,7 @@ namespace AudioSourceHost
 
         public AudioSourceWrapper()
         {
-            var basePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            LogManager.Configuration = new XmlLoggingConfiguration(Path.Combine(basePath, "nlog.config"));
+            AudioBandLogManager.Initialize();
         }
 
         public event EventHandler<SettingChangedEventArgs> SettingChanged;
@@ -99,7 +96,7 @@ namespace AudioSourceHost
         {
             try
             {
-                _logger = LogManager.GetLogger($"AudioSourceWrapper({new DirectoryInfo(audioSourceDirectory).Name})");
+                _logger = AudioBandLogManager.GetLogger($"AudioSourceWrapper({new DirectoryInfo(audioSourceDirectory).Name})");
                 _logger.Debug("Initializing wrapper");
                 _audioSource = AudioSourceLoader.LoadFromDirectory(audioSourceDirectory);
                 _audioSource.Logger = new AudioSourceLogger(_audioSource.Name);

--- a/src/AudioSourceHost/packages.config
+++ b/src/AudioSourceHost/packages.config
@@ -2,6 +2,5 @@
 <packages>
   <package id="FastMember" version="1.4.1" targetFramework="net461" />
   <package id="Nett" version="0.10.1" targetFramework="net461" />
-  <package id="NLog" version="4.5.11" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net461" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Moved logging into a separate project so that both the main audioband project and the host project can use reference it and configuration can be set up in one location.

Also updating logging to use recommended message templates in the formatting. For exception logging, I added the [demystifier](https://github.com/benaadams/Ben.Demystifier) library to make it easier to read stack traces.