### PR TITLE
Spotify Unhandled exception handling

### DIFF
--- a/src/AudioBand.Logging/AudioBandExceptionLayoutRenderer.cs
+++ b/src/AudioBand.Logging/AudioBandExceptionLayoutRenderer.cs
@@ -18,6 +18,9 @@ namespace AudioBand.Logging
             sb.AppendLine("---START OF EXCEPTION---");
             sb.AppendLine(ex.ToStringDemystified());
             sb.AppendLine("---END OF EXCEPTION---");
+            sb.AppendLine("---ORIGINAL EXCEPTION---");
+            sb.AppendLine(ex.ToString());
+            sb.AppendLine("---END OF ORIGINAL EXCEPTION");
         }
     }
 }

--- a/src/AudioSourceHost/AudioSourceWrapper.cs
+++ b/src/AudioSourceHost/AudioSourceWrapper.cs
@@ -98,6 +98,9 @@ namespace AudioSourceHost
             {
                 _logger = AudioBandLogManager.GetLogger($"AudioSourceWrapper({new DirectoryInfo(audioSourceDirectory).Name})");
                 _logger.Debug("Initializing wrapper");
+
+                AppDomain.CurrentDomain.UnhandledException += (o, e) => _logger.Error(e.ExceptionObject as Exception, "Unhandled exception in wrapper");
+
                 _audioSource = AudioSourceLoader.LoadFromDirectory(audioSourceDirectory);
                 _audioSource.Logger = new AudioSourceLogger(_audioSource.Name);
 

--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -328,17 +328,24 @@ namespace SpotifyAudioSource
 
         private async void OnAuthReceived(object sender, AuthorizationCode payload)
         {
-            _auth.Stop();
-            if (payload.Error != null)
+            try
             {
-                Logger.Warn($"Error with authorization: {payload.Error}");
-                return;
+                _auth.Stop();
+                if (payload.Error != null)
+                {
+                    Logger.Warn($"Error with authorization: {payload.Error}");
+                    return;
+                }
+
+                Logger.Debug("Authorization recieved");
+
+                var token = await _auth.ExchangeCode(payload.Code);
+                UpdateAccessToken(token);
             }
-
-            Logger.Debug("Authorization recieved");
-
-            var token = await _auth.ExchangeCode(payload.Code);
-            UpdateAccessToken(token);
+            catch (Exception e)
+            {
+                Logger.Error($"Error with authorization {e}");
+            }
         }
 
         private void UpdateProxy()

--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -609,6 +609,17 @@ namespace SpotifyAudioSource
                 return;
             }
 
+            if (token == null)
+            {
+                Logger.Warn("Token is null");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(token.AccessToken))
+            {
+                Logger.Warn("Access token is null");
+            }
+
             _spotifyApi = new SpotifyWebAPI(UseProxy ? _proxyConfig : null)
             {
                 AccessToken = token.AccessToken,
@@ -621,7 +632,7 @@ namespace SpotifyAudioSource
             }
 
             var expiresIn = TimeSpan.FromSeconds(token.ExpiresIn);
-            Logger.Debug($"Received new access token. Expires in: {expiresIn} (At {DateTime.Now + expiresIn}). Token: {token.AccessToken.Substring(0, 20)}...");
+            Logger.Debug($"Received new access token. Expires in: {expiresIn} (At {DateTime.Now + expiresIn})");
         }
     }
 }


### PR DESCRIPTION
Add some checks for access token in spotify because it was throwing null pointer exceptions when access token is null.

Also some QOL changes to exception logging.