### PR TITLE
Fix next and previous button image not scaling properly

### DIFF
--- a/src/AudioBand/ViewModels/NextButtonVM.cs
+++ b/src/AudioBand/ViewModels/NextButtonVM.cs
@@ -22,8 +22,7 @@ namespace AudioBand.ViewModels
 
         public Image Image
         {
-            // Need padding to fit image in a button.
-            get => _image.Scale(Width - 1, Height - 1);
+            get => _image;
             set => SetProperty(ref _image, value);
         }
 

--- a/src/AudioBand/ViewModels/PreviousButtonVM.cs
+++ b/src/AudioBand/ViewModels/PreviousButtonVM.cs
@@ -22,8 +22,7 @@ namespace AudioBand.ViewModels
 
         public Image Image
         {
-            // Need padding to fit image in a button.
-            get => _image.Scale(Width - 1, Height - 1);
+            get => _image;
             set => SetProperty(ref _image, value);
         }
 


### PR DESCRIPTION
Since scaling is handled by the control now, the viewmodel doesn't need to scale the image itself