### PR TITLE
Add support for Text Label Scroll Speed of 0

### DIFF
--- a/src/AudioBand/Views/Wpf/Behaviours/NumericInputType.cs
+++ b/src/AudioBand/Views/Wpf/Behaviours/NumericInputType.cs
@@ -29,5 +29,10 @@
         /// Any integer.
         /// </summary>
         Integer,
+
+        /// <summary>
+        /// Integer 0 or greater.
+        /// </summary>
+        WholeNumber,
     }
 }

--- a/src/AudioBand/Views/Wpf/CustomLabelSettingsView.xaml
+++ b/src/AudioBand/Views/Wpf/CustomLabelSettingsView.xaml
@@ -97,7 +97,7 @@
 
         <Label Grid.Row="10" Grid.Column="0" Content="{StaticResource ScrollSpeedLabelText}" />
         <metro:NumericUpDown Grid.Row="10" Grid.Column="1" 
-                             behaviours:NumericInput.Type="Size"
+                             behaviours:NumericInput.Type="WholeNumber"
                              Value="{Binding ScrollSpeed, Mode=TwoWay}"/>
 
         <StackPanel Grid.Row="11" Grid.Column="0" Orientation="Horizontal"

--- a/src/AudioBand/Views/Wpf/Resources/Style.xaml
+++ b/src/AudioBand/Views/Wpf/Resources/Style.xaml
@@ -120,6 +120,11 @@
                         <Setter Property="NumericInputMode" Value="Numbers"/>
                         <Setter Property="Interval" Value="1"/>
                     </Trigger>
+                    <Trigger Property="behaviours:NumericInput.Type" Value="WholeNumber">
+                        <Setter Property="NumericInputMode" Value="Numbers"/>
+                        <Setter Property="Minimum" Value="0"/>
+                        <Setter Property="Interval" Value="1"/>
+                    </Trigger>
                 </Style.Triggers>
             </Style>
         </Style.Resources>


### PR DESCRIPTION
Create WholeNumber NumericInputType for Integer 0 or greater.
Update Style.xaml to include WholeNumber with a Minimum value of 0.
Change ScrollSpeed NumericInput.Type to WholeNumber.