### PR TITLE
Fix stylecop warnings about missing periods in sentences

### DIFF
--- a/src/AudioBand.AudioSource/AudioSourceSettingAttribute.cs
+++ b/src/AudioBand.AudioSource/AudioSourceSettingAttribute.cs
@@ -3,7 +3,7 @@
 namespace AudioBand.AudioSource
 {
     /// <summary>
-    /// Represents a setting that is exposed to the user to modify
+    /// Represents a setting that is exposed to the user to modify.
     /// </summary>
     /// <inheritdoc cref="Attribute"/>
     [AttributeUsage(AttributeTargets.Property)]

--- a/src/AudioBand.AudioSource/IAudioSourceLogger.cs
+++ b/src/AudioBand.AudioSource/IAudioSourceLogger.cs
@@ -20,7 +20,7 @@
         /// <summary>
         /// Log an info level message.
         /// </summary>
-        /// <param name="message">Message to be logged</param>
+        /// <param name="message">Message to be logged.</param>
         void Info(string message);
 
         /// <summary>
@@ -32,7 +32,7 @@
         /// <summary>
         /// Log a warning level message.
         /// </summary>
-        /// <param name="message">Message to be logged</param>
+        /// <param name="message">Message to be logged.</param>
         void Warn(string message);
 
         /// <summary>
@@ -44,7 +44,7 @@
         /// <summary>
         /// Log an error level message.
         /// </summary>
-        /// <param name="message">Message to be logged</param>
+        /// <param name="message">Message to be logged.</param>
         void Error(string message);
 
         /// <summary>

--- a/src/AudioBand.AudioSource/ISupportsRatings.cs
+++ b/src/AudioBand.AudioSource/ISupportsRatings.cs
@@ -16,7 +16,7 @@ namespace AudioBand.AudioSource
         /// <summary>
         /// Called when a new rating is being set.
         /// </summary>
-        /// <param name="newRating">The new rating of the track</param>
+        /// <param name="newRating">The new rating of the track.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous set rating operation.</returns>
         Task SetTrackRatingAsync(TrackRating newRating);
     }

--- a/src/AudioBand.AudioSource/TrackInfoChangedEventArgs.cs
+++ b/src/AudioBand.AudioSource/TrackInfoChangedEventArgs.cs
@@ -28,7 +28,7 @@ namespace AudioBand.AudioSource
         }
 
         /// <summary>
-        /// Gets or sets the track Name
+        /// Gets or sets the track Name.
         /// </summary>
         /// <value>The name of the track.</value>
         public string TrackName { get; set; }
@@ -52,7 +52,7 @@ namespace AudioBand.AudioSource
         public string Album { get; set; }
 
         /// <summary>
-        /// Gets or sets the length of the track
+        /// Gets or sets the length of the track.
         /// </summary>
         /// <value>The length of the track.</value>
         public TimeSpan TrackLength { get; set; }

--- a/src/AudioBand.AudioSource/TrackRating.cs
+++ b/src/AudioBand.AudioSource/TrackRating.cs
@@ -18,6 +18,6 @@
         /// <summary>
         /// The song has a negative rating.
         /// </summary>
-        Negative
+        Negative,
     }
 }

--- a/src/AudioBand/AudioSource/AudioSourceProxy.cs
+++ b/src/AudioBand/AudioSource/AudioSourceProxy.cs
@@ -114,7 +114,7 @@ namespace AudioBand.AudioSource
         /// <summary>
         /// Get or set a setting.
         /// </summary>
-        /// <param name="settingName">Name of the setting</param>
+        /// <param name="settingName">Name of the setting.</param>
         /// <returns>The setting value.</returns>
         public object this[string settingName]
         {

--- a/src/AudioBand/Commands/AsyncRelayCommand.cs
+++ b/src/AudioBand/Commands/AsyncRelayCommand.cs
@@ -56,7 +56,7 @@ namespace AudioBand.Commands
         /// Execute the command asynchronously.
         /// </summary>
         /// <param name="parameter">Command paramerter.</param>
-        /// <returns>Task</returns>
+        /// <returns>Task.</returns>
         public async Task ExecuteAsync(object parameter)
         {
             await _execute((T)parameter);

--- a/src/AudioBand/Commands/RelayCommand.cs
+++ b/src/AudioBand/Commands/RelayCommand.cs
@@ -17,7 +17,7 @@ namespace AudioBand.Commands
         /// Initializes a new instance of the <see cref="RelayCommand"/> class.
         /// with an action to be executed and a predicate to determine if it can be executed.
         /// </summary>
-        /// <param name="execute">Action to execute</param>
+        /// <param name="execute">Action to execute.</param>
         /// <param name="canExecute">Predicate to check if the command can be executed.</param>
         public RelayCommand(Action<object> execute, Predicate<object> canExecute)
             : base(execute, canExecute) { }

--- a/src/AudioBand/Commands/RelayCommand{T}.cs
+++ b/src/AudioBand/Commands/RelayCommand{T}.cs
@@ -62,7 +62,7 @@ namespace AudioBand.Commands
         /// Observes a <see cref="INotifyPropertyChanged"/> subject and raises <see cref="CanExecuteChanged"/> when a property changes.
         /// </summary>
         /// <param name="subject">The subject to observe.</param>
-        /// <param name="propertyName">The property to observe</param>
+        /// <param name="propertyName">The property to observe.</param>
         public void Observe(INotifyPropertyChanged subject, string propertyName)
         {
             subject.PropertyChanged += (o, e) =>
@@ -77,7 +77,7 @@ namespace AudioBand.Commands
         /// <summary>
         /// Observes a <see cref="INotifyCollectionChanged"/> subject and raises <see cref="CanExecuteChanged"/> when the collection changes.
         /// </summary>
-        /// <param name="subject">The subject</param>
+        /// <param name="subject">The subject.</param>
         public void Observe(INotifyCollectionChanged subject)
         {
             subject.CollectionChanged += (o, e) => RaiseCanExecuteChanged();

--- a/src/AudioBand/Deskband.cs
+++ b/src/AudioBand/Deskband.cs
@@ -17,7 +17,7 @@ using SimpleInjector;
 namespace AudioBand
 {
     /// <summary>
-    /// Entry point of the application
+    /// Entry point of the application.
     /// </summary>
     [ComVisible(true)]
     [Guid("957D8782-5B07-4126-9B24-1E917BAAAD64")]

--- a/src/AudioBand/Extensions/ImageExtensions.cs
+++ b/src/AudioBand/Extensions/ImageExtensions.cs
@@ -50,10 +50,10 @@ namespace AudioBand.Extensions
         /// <summary>
         /// Scale an image to fill as much space as possible while maintaining aspect ratio.
         /// </summary>
-        /// <param name="image">The image to scale</param>
+        /// <param name="image">The image to scale.</param>
         /// <param name="targetWidth">The target width.</param>
         /// <param name="targetHeight">The target height.</param>
-        /// <returns>The scaled image</returns>
+        /// <returns>The scaled image.</returns>
         public static Image GetScaledSize(this IImage image, int targetWidth, int targetHeight)
         {
             var size = Scale(image.DesiredSize, new Size(targetWidth, targetHeight));

--- a/src/AudioBand/Extensions/SvgExtensions.cs
+++ b/src/AudioBand/Extensions/SvgExtensions.cs
@@ -14,7 +14,7 @@ namespace AudioBand.Extensions
         /// Convert to a bitmap.
         /// </summary>
         /// <param name="svg">Svg to convert.</param>
-        /// <returns>A bitmap representation of the svg</returns>
+        /// <returns>A bitmap representation of the svg.</returns>
         public static Bitmap ToBitmap(this SvgDocument svg)
         {
             return ToBitmap(svg, (int)svg.Width.Value, (int)svg.Height.Value);
@@ -26,7 +26,7 @@ namespace AudioBand.Extensions
         /// <param name="svg">Svg to convert.</param>
         /// <param name="width">Width of the converted image.</param>
         /// <param name="height">Height of the converted image.</param>
-        /// <returns>A bitmap representation of the svg</returns>
+        /// <returns>A bitmap representation of the svg.</returns>
         public static Bitmap ToBitmap(this SvgDocument svg, int width, int height)
         {
             return svg.Draw(width, height);

--- a/src/AudioBand/MainControl.Bindings.cs
+++ b/src/AudioBand/MainControl.Bindings.cs
@@ -7,7 +7,7 @@ using AudioBand.Views.Winforms;
 namespace AudioBand
 {
     /// <summary>
-    /// Partial main control
+    /// Partial main control.
     /// </summary>
     partial class MainControl
     {

--- a/src/AudioBand/MainControl.cs
+++ b/src/AudioBand/MainControl.cs
@@ -39,8 +39,8 @@ namespace AudioBand
         /// <param name="options">The deskband options.</param>
         /// <param name="info">The taskbar info.</param>
         /// <param name="track">The track model.</param>
-        /// <param name="appsettings">The app settings</param>
-        /// <param name="audiosourceMananger">The audio source manager</param>
+        /// <param name="appsettings">The app settings.</param>
+        /// <param name="audiosourceMananger">The audio source manager.</param>
         /// <param name="viewModelContainer">The settings window.</param>
         /// <param name="labelService">The label service.</param>
         /// <param name="messageBus">The message bus.</param>
@@ -82,7 +82,7 @@ namespace AudioBand
         public TaskbarInfo TaskbarInfo { get; }
 
         /// <summary>
-        /// Save on close
+        /// Save on close.
         /// </summary>
         public void CloseAudioband()
         {
@@ -98,7 +98,7 @@ namespace AudioBand
         }
 
         /// <summary>
-        /// Update deskband options when the size changes
+        /// Update deskband options when the size changes.
         /// </summary>
         /// <param name="eventArgs">.</param>
         protected override void OnResize(EventArgs eventArgs)

--- a/src/AudioBand/Messages/FocusChangedMessage.cs
+++ b/src/AudioBand/Messages/FocusChangedMessage.cs
@@ -1,13 +1,13 @@
 ﻿namespace AudioBand.Messages
 {
     /// <summary>
-    /// Messages for focus change
+    /// Messages for focus change.
     /// </summary>
     public enum FocusChangedMessage
     {
         /// <summary>
         /// Focus captured
         /// </summary>
-        FocusCaptured
+        FocusCaptured,
     }
 }

--- a/src/AudioBand/Models/AlbumArtPopup.cs
+++ b/src/AudioBand/Models/AlbumArtPopup.cs
@@ -21,7 +21,7 @@
         }
 
         /// <summary>
-        /// Gets or sets the width of the album art popup
+        /// Gets or sets the width of the album art popup.
         /// </summary>
         public int Width
         {

--- a/src/AudioBand/Models/CustomLabel.cs
+++ b/src/AudioBand/Models/CustomLabel.cs
@@ -38,7 +38,7 @@ namespace AudioBand.Models
             /// <summary>
             /// Align the text in the center.
             /// </summary>
-            Center
+            Center,
         }
 
         /// <summary>

--- a/src/AudioBand/Models/ModelBase.cs
+++ b/src/AudioBand/Models/ModelBase.cs
@@ -23,14 +23,14 @@ namespace AudioBand.Models
         public event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary>
-        /// Gets the logger for the model
+        /// Gets the logger for the model.
         /// </summary>
         protected ILogger Logger { get; }
 
         /// <summary>
         /// Raises the <see cref="PropertyChanged"/> event.
         /// </summary>
-        /// <param name="propertyName">Name of the property that changed</param>
+        /// <param name="propertyName">Name of the property that changed.</param>
         protected void RaisePropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/src/AudioBand/Models/PlaybackButtonBase.cs
+++ b/src/AudioBand/Models/PlaybackButtonBase.cs
@@ -3,7 +3,7 @@
 namespace AudioBand.Models
 {
     /// <summary>
-    /// Base class for next and previous button
+    /// Base class for next and previous button.
     /// </summary>
     public class PlaybackButtonBase : ModelBase
     {

--- a/src/AudioBand/Models/ProgressBar.cs
+++ b/src/AudioBand/Models/ProgressBar.cs
@@ -35,7 +35,7 @@ namespace AudioBand.Models
         }
 
         /// <summary>
-        /// Gets or sets the hover color
+        /// Gets or sets the hover color.
         /// </summary>
         public Color HoverColor
         {

--- a/src/AudioBand/Models/Track.cs
+++ b/src/AudioBand/Models/Track.cs
@@ -85,7 +85,7 @@ namespace AudioBand.Models
         }
 
         /// <summary>
-        /// Sets the placeholder image
+        /// Sets the placeholder image.
         /// </summary>
         public IImage PlaceHolderImage
         {

--- a/src/AudioBand/Resources/DrawingImage.cs
+++ b/src/AudioBand/Resources/DrawingImage.cs
@@ -4,7 +4,7 @@ using AudioBand.Extensions;
 namespace AudioBand.Resources
 {
     /// <summary>
-    /// Image class for system.drawing images
+    /// Image class for system.drawing images.
     /// </summary>
     public class DrawingImage : IImage
     {
@@ -13,7 +13,7 @@ namespace AudioBand.Resources
         /// <summary>
         /// Initializes a new instance of the <see cref="DrawingImage"/> class.
         /// </summary>
-        /// <param name="image">The image to use</param>
+        /// <param name="image">The image to use.</param>
         public DrawingImage(Image image)
         {
             _internalImage = image;

--- a/src/AudioBand/Resources/IImage.cs
+++ b/src/AudioBand/Resources/IImage.cs
@@ -3,21 +3,21 @@
 namespace AudioBand.Resources
 {
     /// <summary>
-    /// Interface to wraps images
+    /// Interface to wraps images.
     /// </summary>
     public interface IImage
     {
         /// <summary>
-        /// Gets the desired size
+        /// Gets the desired size.
         /// </summary>
         Size DesiredSize { get; }
 
         /// <summary>
-        /// Gets an image instance
+        /// Gets an image instance.
         /// </summary>
         /// <param name="width">The target width.</param>
         /// <param name="height">The target height.</param>
-        /// <returns>An image</returns>
+        /// <returns>An image.</returns>
         Image Draw(int width, int height);
     }
 }

--- a/src/AudioBand/Resources/IResourceLoader.cs
+++ b/src/AudioBand/Resources/IResourceLoader.cs
@@ -1,7 +1,7 @@
 ﻿namespace AudioBand.Resources
 {
     /// <summary>
-    /// Loads audioband resources
+    /// Loads audioband resources.
     /// </summary>
     public interface IResourceLoader
     {
@@ -34,7 +34,7 @@
         /// Tries to load an image from a path or returns the fallback image if it fails.
         /// </summary>
         /// <param name="path">The file path of the image.</param>
-        /// <param name="fallbackImage">The fallback image if unable to load.s</param>
+        /// <param name="fallbackImage">The fallback image if unable to load.</param>
         /// <returns>The image from the path or the fallback image.</returns>
         IImage TryLoadImageFromPath(string path, IImage fallbackImage);
     }

--- a/src/AudioBand/Resources/ResourceLoader.cs
+++ b/src/AudioBand/Resources/ResourceLoader.cs
@@ -8,7 +8,7 @@ using Svg;
 namespace AudioBand.Resources
 {
     /// <summary>
-    /// Default resource loader
+    /// Default resource loader.
     /// </summary>
     public class ResourceLoader : IResourceLoader
     {

--- a/src/AudioBand/Resources/SvgImage.cs
+++ b/src/AudioBand/Resources/SvgImage.cs
@@ -5,7 +5,7 @@ using Svg;
 namespace AudioBand.Resources
 {
     /// <summary>
-    /// Image class for svgs
+    /// Image class for svgs.
     /// </summary>
     public class SvgImage : IImage
     {

--- a/src/AudioBand/Settings/Migrations/ISettingsMigrator.cs
+++ b/src/AudioBand/Settings/Migrations/ISettingsMigrator.cs
@@ -1,7 +1,7 @@
 ﻿namespace AudioBand.Settings.Migrations
 {
     /// <summary>
-    /// Migrates settings from one version to another
+    /// Migrates settings from one version to another.
     /// </summary>
     internal interface ISettingsMigrator
     {

--- a/src/AudioBand/Settings/Migrations/Migration.cs
+++ b/src/AudioBand/Settings/Migrations/Migration.cs
@@ -7,14 +7,14 @@ using NLog;
 namespace AudioBand.Settings.Migrations
 {
     /// <summary>
-    /// Migrate settings from one version to another
+    /// Migrate settings from one version to another.
     /// </summary>
     internal static class Migration
     {
         private static readonly Dictionary<(string From, string To), ISettingsMigrator> SupportedMigrations = new Dictionary<(string From, string To), ISettingsMigrator>()
         {
             { ("0.1", "2"), new V1ToV2() },
-            { ("2", "3"), new V2ToV3() }
+            { ("2", "3"), new V2ToV3() },
         };
 
         private static readonly ILogger Logger = AudioBandLogManager.GetLogger(typeof(Migration).FullName);

--- a/src/AudioBand/Settings/Migrations/V2ToV3.cs
+++ b/src/AudioBand/Settings/Migrations/V2ToV3.cs
@@ -7,7 +7,7 @@ using AutoMapper;
 namespace AudioBand.Settings.Migrations
 {
     /// <summary>
-    /// Migrates settings from v2 to v3
+    /// Migrates settings from v2 to v3.
     /// </summary>
     public class V2ToV3 : ISettingsMigrator
     {

--- a/src/AudioBand/ViewModels/AudioSourceSettingVM.cs
+++ b/src/AudioBand/ViewModels/AudioSourceSettingVM.cs
@@ -6,7 +6,7 @@ using AudioSourceHost;
 namespace AudioBand.ViewModels
 {
     /// <summary>
-    /// View model for <see cref="AudioSourceSetting"/>. Represents one key-value pair
+    /// View model for <see cref="AudioSourceSetting"/>. Represents one key-value pair.
     /// </summary>
     public class AudioSourceSettingVM : ViewModelBase<AudioSourceSetting>
     {
@@ -15,7 +15,7 @@ namespace AudioBand.ViewModels
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AudioSourceSettingVM"/> class
-        /// with the model, setting information and if it was saved,
+        /// with the model, setting information and if it was saved.
         /// </summary>
         /// <param name="audioSource">The associated <see cref="IInternalAudioSource"/>.</param>
         /// <param name="model">The <see cref="AudioSource"/>.</param>
@@ -94,7 +94,7 @@ namespace AudioBand.ViewModels
         public int Priority => _settingAttribute.Priority;
 
         /// <summary>
-        /// Applies the value to the audio source
+        /// Applies the value to the audio source.
         /// </summary>
         public void ApplyChanges()
         {

--- a/src/AudioBand/ViewModels/AudioSourceSettingsVM.cs
+++ b/src/AudioBand/ViewModels/AudioSourceSettingsVM.cs
@@ -6,7 +6,7 @@ using AudioBand.Models;
 namespace AudioBand.ViewModels
 {
     /// <summary>
-    /// View model for all audio source settings
+    /// View model for all audio source settings.
     /// </summary>
     public class AudioSourceSettingsVM : ViewModelBase<AudioSourceSettings>
     {

--- a/src/AudioBand/ViewModels/ConfirmationDialogType.cs
+++ b/src/AudioBand/ViewModels/ConfirmationDialogType.cs
@@ -1,7 +1,7 @@
 ﻿namespace AudioBand.ViewModels
 {
     /// <summary>
-    /// Types for confirmation dialogs
+    /// Types for confirmation dialogs.
     /// </summary>
     public enum ConfirmationDialogType
     {

--- a/src/AudioBand/ViewModels/CustomLabelVM.cs
+++ b/src/AudioBand/ViewModels/CustomLabelVM.cs
@@ -19,8 +19,8 @@ namespace AudioBand.ViewModels
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomLabelVM"/> class.
         /// </summary>
-        /// <param name="model">The custom label</param>
-        /// <param name="dialogService">The dialog service</param>
+        /// <param name="model">The custom label.</param>
+        /// <param name="dialogService">The dialog service.</param>
         public CustomLabelVM(CustomLabel model, IDialogService dialogService)
             : base(model)
         {
@@ -133,7 +133,7 @@ namespace AudioBand.ViewModels
         public IEnumerable<TextAlignment> TextAlignValues { get; } = Enum.GetValues(typeof(TextAlignment)).Cast<TextAlignment>();
 
         /// <summary>
-        /// Gets the dialog service
+        /// Gets the dialog service.
         /// </summary>
         public IDialogService DialogService { get; private set; }
     }

--- a/src/AudioBand/ViewModels/ICustomLabelService.cs
+++ b/src/AudioBand/ViewModels/ICustomLabelService.cs
@@ -3,7 +3,7 @@
 namespace AudioBand.ViewModels
 {
     /// <summary>
-    /// Represents a service to add and remove new custom labels
+    /// Represents a service to add and remove new custom labels.
     /// </summary>
     public interface ICustomLabelService
     {
@@ -35,7 +35,7 @@ namespace AudioBand.ViewModels
         void RemoveCustomTextLabel(CustomLabelVM label);
 
         /// <summary>
-        /// Clears all labels
+        /// Clears all labels.
         /// </summary>
         void ClearCustomLabels();
     }

--- a/src/AudioBand/ViewModels/IDialogService.cs
+++ b/src/AudioBand/ViewModels/IDialogService.cs
@@ -29,15 +29,15 @@ namespace AudioBand.ViewModels
         void ShowAboutDialog();
 
         /// <summary>
-        /// Show the rename dialog
+        /// Show the rename dialog.
         /// </summary>
-        /// <param name="currentName">The current name</param>
-        /// <param name="profiles">The list of profiles</param>
+        /// <param name="currentName">The current name.</param>
+        /// <param name="profiles">The list of profiles.</param>
         /// <returns>Null if canceled, otherwise the new name.</returns>
         string ShowRenameDialog(string currentName, IEnumerable<string> profiles);
 
         /// <summary>
-        /// Show the image picker dialog
+        /// Show the image picker dialog.
         /// </summary>
         /// <returns>The path of the image.</returns>
         string ShowImagePickerDialog();

--- a/src/AudioBand/ViewModels/PreviousButtonVM.cs
+++ b/src/AudioBand/ViewModels/PreviousButtonVM.cs
@@ -14,7 +14,7 @@ namespace AudioBand.ViewModels
         /// </summary>
         /// <param name="appSettings">The app settings.</param>
         /// <param name="resourceLoader">The resource loader.</param>
-        /// <param name="dialogService">The dialog service</param>
+        /// <param name="dialogService">The dialog service.</param>
         public PreviousButtonVM(IAppSettings appSettings, IResourceLoader resourceLoader, IDialogService dialogService)
             : base(appSettings, resourceLoader, dialogService, appSettings.PreviousButton)
         {

--- a/src/AudioBand/ViewModels/RenameProfileDialogVM.cs
+++ b/src/AudioBand/ViewModels/RenameProfileDialogVM.cs
@@ -76,7 +76,7 @@ namespace AudioBand.ViewModels
         }
 
         /// <summary>
-        /// Gets the ok command
+        /// Gets the ok command.
         /// </summary>
         public RelayCommand OkCommand { get; }
 

--- a/src/AudioBand/ViewModels/SettingsWindowVM.cs
+++ b/src/AudioBand/ViewModels/SettingsWindowVM.cs
@@ -119,7 +119,7 @@ namespace AudioBand.ViewModels
         }
 
         /// <summary>
-        /// Gets the list of profiles
+        /// Gets the list of profiles.
         /// </summary>
         public ObservableCollection<string> Profiles { get; }
 

--- a/src/AudioBand/ViewModels/ViewModelBase.cs
+++ b/src/AudioBand/ViewModels/ViewModelBase.cs
@@ -166,7 +166,7 @@ namespace AudioBand.ViewModels
         }
 
         /// <summary>
-        /// Notifies all properties changed
+        /// Notifies all properties changed.
         /// </summary>
         protected void RaisePropertyChangedAll()
         {
@@ -213,7 +213,7 @@ namespace AudioBand.ViewModels
         /// <param name="newValue">New value of the field.</param>
         /// <param name="trackChanges">True if <see cref="BeginEdit"/> should be called if the value changes.</param>
         /// <param name="propertyName">Name of the property to notify with.</param>
-        /// <returns>Returns true if new value was set</returns>
+        /// <returns>Returns true if new value was set.</returns>
         protected bool SetProperty<TValue>(ref TValue field, TValue newValue, bool trackChanges = true, [CallerMemberName] string propertyName = null)
         {
             if (EqualityComparer<TValue>.Default.Equals(field, newValue))

--- a/src/AudioBand/ViewModels/ViewModelContainer.cs
+++ b/src/AudioBand/ViewModels/ViewModelContainer.cs
@@ -3,7 +3,7 @@
 namespace AudioBand.ViewModels
 {
     /// <summary>
-    /// Container for all the view models
+    /// Container for all the view models.
     /// </summary>
     public class ViewModelContainer : IViewModelContainer
     {
@@ -35,7 +35,7 @@ namespace AudioBand.ViewModels
             NextButtonVM = nextButtonVm;
             PlayPauseButtonVM = playPauseButtonVm;
             PreviousButtonVM = previousButtonVm;
-            ProgressBarVM = progressBarVm;;
+            ProgressBarVM = progressBarVm;
         }
 
         /// <inheritdoc />

--- a/src/AudioBand/Views/Winforms/AlbumArtDisplay.cs
+++ b/src/AudioBand/Views/Winforms/AlbumArtDisplay.cs
@@ -7,14 +7,14 @@ using AudioBand.Resources;
 namespace AudioBand.Views.Winforms
 {
     /// <summary>
-    /// Control for the album art
+    /// Control for the album art.
     /// </summary>
     public class AlbumArtDisplay : AudioBandControl
     {
         private IImage _albumArt;
 
         /// <summary>
-        /// Gets or sets the album art
+        /// Gets or sets the album art.
         /// </summary>
         [Bindable(BindableSupport.Yes)]
         public IImage AlbumArt

--- a/src/AudioBand/Views/Winforms/AudioBandControl.cs
+++ b/src/AudioBand/Views/Winforms/AudioBandControl.cs
@@ -56,7 +56,7 @@ namespace AudioBand.Views.Winforms
         /// <summary>
         /// Gets or sets the logical size of the control.
         /// </summary>
-        /// <remarks>This is the device independent size</remarks>
+        /// <remarks>This is the device independent size.</remarks>
         [Browsable(true)]
         [Bindable(BindableSupport.Yes)]
         public Size LogicalSize
@@ -72,7 +72,7 @@ namespace AudioBand.Views.Winforms
         /// <summary>
         /// Gets or sets the logical position of the control.
         /// </summary>
-        /// <remarks>This is the device independent position</remarks>
+        /// <remarks>This is the device independent position.</remarks>
         [Browsable(true)]
         [Bindable(BindableSupport.Yes)]
         public Point LogicalLocation
@@ -86,19 +86,19 @@ namespace AudioBand.Views.Winforms
         }
 
         /// <summary>
-        /// Gets the dpi
+        /// Gets the dpi.
         /// </summary>
         public double Dpi { get; private set; } = LogicalDpi;
 
         /// <summary>
-        /// Gets the scaling factor
+        /// Gets the scaling factor.
         /// </summary>
         public double ScalingFactor => Dpi / LogicalDpi;
 
         /// <summary>
         /// Gets the size scaled by the <see cref="ScalingFactor"/>.
         /// </summary>
-        /// <param name="size">The size to scale</param>
+        /// <param name="size">The size to scale.</param>
         /// <returns>The new scaled size.</returns>
         protected Size GetScaledSize(Size size)
         {
@@ -106,9 +106,9 @@ namespace AudioBand.Views.Winforms
         }
 
         /// <summary>
-        /// Gets the point scaled by the <see cref="ScalingFactor"/>
+        /// Gets the point scaled by the <see cref="ScalingFactor"/>.
         /// </summary>
-        /// <param name="point">The point to scale</param>
+        /// <param name="point">The point to scale.</param>
         /// <returns>The new scaled point.</returns>
         protected Point GetScaledPoint(Point point)
         {
@@ -131,7 +131,7 @@ namespace AudioBand.Views.Winforms
         }
 
         /// <summary>
-        /// Occurs when dpi changed
+        /// Occurs when dpi changed.
         /// </summary>
         protected virtual void OnDpiChanged()
         {

--- a/src/AudioBand/Views/Winforms/AudioBandTooltip.cs
+++ b/src/AudioBand/Views/Winforms/AudioBandTooltip.cs
@@ -7,7 +7,7 @@ using System.Windows.Forms;
 namespace AudioBand.Views.Winforms
 {
     /// <summary>
-    /// Custom tooltip class
+    /// Custom tooltip class.
     /// </summary>
     public abstract class AudioBandTooltip : ToolTip, IBindableComponent
     {
@@ -29,7 +29,7 @@ namespace AudioBand.Views.Winforms
         }
 
         /// <summary>
-        /// Flags for the positioning of the tooltip
+        /// Flags for the positioning of the tooltip.
         /// </summary>
         [Flags]
         protected enum PositionType
@@ -76,11 +76,11 @@ namespace AudioBand.Views.Winforms
         protected abstract void OnPopup(PopupEventArgs popupEventArgs);
 
         /// <summary>
-        /// Shows the tooltip without focus being required
+        /// Shows the tooltip without focus being required.
         /// </summary>
         /// <param name="parent">The parent control to show the tooltip over.</param>
         /// <param name="positionType">The type of positioning used to interpret <paramref name="position"/>.</param>
-        /// <param name="position">The position of the tooltip</param>
+        /// <param name="position">The position of the tooltip.</param>
         protected void Show(Control parent, PositionType positionType, Point position)
         {
             _setToolMethod.Invoke(this, new object[] { parent, _name, positionType, position });

--- a/src/AudioBand/Views/Winforms/CustomButton.cs
+++ b/src/AudioBand/Views/Winforms/CustomButton.cs
@@ -9,7 +9,7 @@ using AudioBand.Resources;
 namespace AudioBand.Views.Winforms
 {
     /// <summary>
-    /// Custom button
+    /// Custom button.
     /// </summary>
     public class CustomButton : AudioBandControl
     {
@@ -33,19 +33,19 @@ namespace AudioBand.Views.Winforms
         }
 
         /// <summary>
-        /// Gets or sets the buttons image when hovered
+        /// Gets or sets the buttons image when hovered.
         /// </summary>
         [Bindable(BindableSupport.Yes)]
         public IImage HoveredImage { get; set; }
 
         /// <summary>
-        /// Gets or sets the buttons image when clicked
+        /// Gets or sets the buttons image when clicked.
         /// </summary>
         [Bindable(BindableSupport.Yes)]
         public IImage ClickedImage { get; set; }
 
         /// <summary>
-        /// Gets or sets the default back color
+        /// Gets or sets the default back color.
         /// </summary>
         [Bindable(BindableSupport.Yes)]
         public Color DefaultBackgroundColor
@@ -60,13 +60,13 @@ namespace AudioBand.Views.Winforms
         }
 
         /// <summary>
-        /// Gets or sets the hover back color
+        /// Gets or sets the hover back color.
         /// </summary>
         [Bindable(BindableSupport.Yes)]
         public Color HoveredBackgroundColor { get; set; } = Color.FromArgb(25, 255, 255, 255);
 
         /// <summary>
-        /// Gets or sets the clicked back color
+        /// Gets or sets the clicked back color.
         /// </summary>
         [Bindable(BindableSupport.Yes)]
         public Color ClickedBackgroundColor { get; set; } = Color.FromArgb(15, 255, 255, 255);

--- a/src/AudioBand/Views/Winforms/EnhancedProgressBar.cs
+++ b/src/AudioBand/Views/Winforms/EnhancedProgressBar.cs
@@ -46,7 +46,7 @@ namespace AudioBand.Views.Winforms
         }
 
         /// <summary>
-        /// Gets or sets the hover color
+        /// Gets or sets the hover color.
         /// </summary>
         [Browsable(true)]
         [Bindable(BindableSupport.Yes)]

--- a/src/AudioBand/Views/Winforms/FormattedTextLabel.cs
+++ b/src/AudioBand/Views/Winforms/FormattedTextLabel.cs
@@ -308,7 +308,7 @@ namespace AudioBand.Views.Winforms
         }
 
         /// <summary>
-        /// Get the text position when not scrolling
+        /// Get the text position when not scrolling.
         /// </summary>
         /// <returns>The x position.</returns>
         private int GetNormalTextPos()

--- a/src/AudioBand/Views/Winforms/FormattedTextRenderer.cs
+++ b/src/AudioBand/Views/Winforms/FormattedTextRenderer.cs
@@ -112,7 +112,7 @@ namespace AudioBand.Views.Winforms
             /// <summary>
             /// Text is underlined.
             /// </summary>
-            Underline = 256
+            Underline = 256,
         }
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace AudioBand.Views.Winforms
         /// <summary>
         /// Draws the formatted text with the current values.
         /// </summary>
-        /// <param name="scaling">The scaling factor</param>
+        /// <param name="scaling">The scaling factor.</param>
         /// <returns>A bitmap of the rendered text.</returns>
         public Bitmap Draw(double scaling)
         {
@@ -263,7 +263,7 @@ namespace AudioBand.Views.Winforms
         /// <summary>
         /// Measures the size that the text would be.
         /// </summary>
-        /// <param name="scaling">The scaling factor</param>
+        /// <param name="scaling">The scaling factor.</param>
         /// <returns>The bounds of the text.</returns>
         public Size Measure(double scaling)
         {

--- a/src/AudioBand/Views/Wpf/AboutDialog.xaml.cs
+++ b/src/AudioBand/Views/Wpf/AboutDialog.xaml.cs
@@ -4,7 +4,7 @@ using AudioBand.ViewModels;
 namespace AudioBand.Views.Wpf
 {
     /// <summary>
-    /// Interaction logic for AboutDialog.xaml
+    /// Interaction logic for AboutDialog.xaml.
     /// </summary>
     public partial class AboutDialog
     {

--- a/src/AudioBand/Views/Wpf/Behaviours/AppUserModelID.cs
+++ b/src/AudioBand/Views/Wpf/Behaviours/AppUserModelID.cs
@@ -5,7 +5,7 @@ using System.Windows.Interop;
 namespace AudioBand.Views.Wpf.Behaviours
 {
     /// <summary>
-    /// Attached behaviour that changes the application user model id so that the window is separate from explorer in the taskbar
+    /// Attached behaviour that changes the application user model id so that the window is separate from explorer in the taskbar.
     /// </summary>
     public class AppUserModelID : Behavior<Window>
     {

--- a/src/AudioBand/Views/Wpf/ColorPicker.xaml.cs
+++ b/src/AudioBand/Views/Wpf/ColorPicker.xaml.cs
@@ -6,7 +6,7 @@ using AudioBand.ViewModels;
 namespace AudioBand.Views.Wpf
 {
     /// <summary>
-    /// Interaction logic for ColorPicker.xaml
+    /// Interaction logic for ColorPicker.xaml.
     /// </summary>
     public partial class ColorPicker : UserControl
     {
@@ -16,7 +16,7 @@ namespace AudioBand.Views.Wpf
         public static readonly DependencyProperty ColorProperty = DependencyProperty.Register(nameof(Color), typeof(Color), typeof(ColorPicker));
 
         /// <summary>
-        /// Dependency property for <see cref="DialogService"/>
+        /// Dependency property for <see cref="DialogService"/>.
         /// </summary>
         public static readonly DependencyProperty DialogServiceProperty = DependencyProperty.Register(nameof(DialogService), typeof(IDialogService), typeof(ColorPicker));
 

--- a/src/AudioBand/Views/Wpf/ConfirmationDialog.xaml.cs
+++ b/src/AudioBand/Views/Wpf/ConfirmationDialog.xaml.cs
@@ -4,7 +4,7 @@ using AudioBand.ViewModels;
 namespace AudioBand.Views.Wpf
 {
     /// <summary>
-    /// Interaction logic for ConfirmationDialog.xaml
+    /// Interaction logic for ConfirmationDialog.xaml.
     /// </summary>
     public partial class ConfirmationDialog
     {

--- a/src/AudioBand/Views/Wpf/DialogService.cs
+++ b/src/AudioBand/Views/Wpf/DialogService.cs
@@ -20,7 +20,7 @@ namespace AudioBand.Views.Wpf
             "Tiff Files (*.tiff;*.tif)|*.tiff;*.tif",
             "Png Files (*.png)|*.png",
             "Svg Files (*.svg)|*.svg",
-            "All Files (*.*)|*.*"
+            "All Files (*.*)|*.*",
         };
 
         private static readonly string FileDialogImageFilter = string.Join("|", ImageFilters);
@@ -33,7 +33,7 @@ namespace AudioBand.Views.Wpf
             var colorPickerDialog = new Dsafa.WpfColorPicker.ColorPickerDialog(initialColor)
             {
                 WindowStartupLocation = WindowStartupLocation.CenterScreen,
-                ResizeMode = ResizeMode.NoResize
+                ResizeMode = ResizeMode.NoResize,
             };
 
             var res = colorPickerDialog.ShowDialog();

--- a/src/AudioBand/Views/Wpf/TemplateSelectors/AudioSourceSettingSelector.cs
+++ b/src/AudioBand/Views/Wpf/TemplateSelectors/AudioSourceSettingSelector.cs
@@ -27,7 +27,7 @@ namespace AudioBand.Views.Wpf.TemplateSelectors
             /// <summary>
             /// Template for the setting value.
             /// </summary>
-            Value
+            Value,
         }
 
         /// <summary>

--- a/src/AudioBand/Views/Wpf/ValueConverters/BoolToVisibilityConverter.cs
+++ b/src/AudioBand/Views/Wpf/ValueConverters/BoolToVisibilityConverter.cs
@@ -11,7 +11,7 @@ namespace AudioBand.Views.Wpf.ValueConverters
     internal class BoolToVisibilityConverter : IValueConverter
     {
         /// <summary>
-        /// Gets or sets a value indicating whether to collapse when hidden
+        /// Gets or sets a value indicating whether to collapse when hidden.
         /// </summary>
         public bool Collapse { get; set; } = true;
 

--- a/src/AudioBand/Views/Wpf/ValueConverters/FormatConverter.cs
+++ b/src/AudioBand/Views/Wpf/ValueConverters/FormatConverter.cs
@@ -5,7 +5,7 @@ using System.Windows.Data;
 namespace AudioBand.Views.Wpf.ValueConverters
 {
     /// <summary>
-    /// Converts string with string format
+    /// Converts string with string format..
     /// </summary>
     [ValueConversion(typeof(object), typeof(string), ParameterType = typeof(string))]
     public class FormatConverter : IValueConverter

--- a/src/AudioBand/Views/Wpf/ValueConverters/MultiBindingCommandParameterConverter.cs
+++ b/src/AudioBand/Views/Wpf/ValueConverters/MultiBindingCommandParameterConverter.cs
@@ -5,7 +5,7 @@ using System.Windows.Data;
 namespace AudioBand.Views.Wpf.ValueConverters
 {
     /// <summary>
-    /// Converts multi binding for command parameter
+    /// Converts multi binding for command parameter.
     /// </summary>
     [ValueConversion(typeof(object[]), typeof(object[]))]
     public class MultiBindingCommandParameterConverter : IMultiValueConverter

--- a/src/AudioBand/Views/Wpf/ValueConverters/NumberToNumericUpDownConverter.cs
+++ b/src/AudioBand/Views/Wpf/ValueConverters/NumberToNumericUpDownConverter.cs
@@ -9,7 +9,7 @@ namespace AudioBand.Views.Wpf.ValueConverters
     /// </summary>
     /// <remarks>
     /// There are issues binding a number to the value property of a numericupdown control (double?).
-    /// Example message: Cannot convert from type 'UInt32' to type 'System.Nullable`1[System.Double]
+    /// Example message: Cannot convert from type 'UInt32' to type 'System.Nullable`1[System.Double].
     /// </remarks>
     internal class NumberToNumericUpDownConverter : IValueConverter
     {

--- a/src/AudioBand/Views/Wpf/ValueConverters/ReverseConverter.cs
+++ b/src/AudioBand/Views/Wpf/ValueConverters/ReverseConverter.cs
@@ -8,7 +8,7 @@ namespace AudioBand.Views.Wpf.ValueConverters
     /// <summary>
     /// Reverses the direction of a <see cref="IValueConverter"/>.
     /// </summary>
-    /// <remarks>https://stackoverflow.com/a/19916654</remarks>
+    /// <remarks>https://stackoverflow.com/a/19916654.</remarks>
     [ContentProperty("Converter")]
     public class ReverseConverter : IValueConverter
     {

--- a/src/AudioBand/Views/Wpf/ValueConverters/StringToVisibilityConverter.cs
+++ b/src/AudioBand/Views/Wpf/ValueConverters/StringToVisibilityConverter.cs
@@ -6,7 +6,7 @@ using System.Windows.Data;
 namespace AudioBand.Views.Wpf.ValueConverters
 {
     /// <summary>
-    /// Converts a string to a <see cref="Visibility"/> value;
+    /// Converts a string to a <see cref="Visibility"/> value.
     /// </summary>
     [ValueConversion(typeof(string), typeof(Visibility))]
     public class StringToVisibilityConverter : IValueConverter


### PR DESCRIPTION
These warnings didn't appear before. There are a lot of warnings about missing periods at the end of sentences.