### PR TITLE
Add repeat mode button

### DIFF
--- a/src/AudioBand.Test/ButtonViewModels.cs
+++ b/src/AudioBand.Test/ButtonViewModels.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Drawing;
+using System.Threading.Tasks;
+using AudioBand.AudioSource;
 using AudioBand.Models;
 using AudioBand.Settings;
 using AudioBand.ViewModels;
@@ -82,6 +84,76 @@ namespace AudioBand.Test
             Assert.IsFalse(vm.IsEditing);
             Assert.IsTrue(raised);
             Assert.AreEqual(second.Height, vm.Height);
+        }
+
+        [TestMethod]
+        public void RepeatModeButtonListensForProfileChanges()
+        {
+            var first = new RepeatModeButton() { Height = 1 };
+            var second = new RepeatModeButton() { Height = 2 };
+            _appSettings.SetupSequence(m => m.RepeatModeButton)
+                .Returns(first)
+                .Returns(second);
+
+            var vm = new RepeatModeButtonViewModel(_appSettings.Object, _dialog.Object);
+            bool raised = false;
+            vm.PropertyChanged += (_, __) => raised = true;
+
+            Assert.AreEqual(first.Height, vm.Height);
+            _appSettings.Raise(m => m.ProfileChanged += null, EventArgs.Empty);
+
+            Assert.IsFalse(vm.IsEditing);
+            Assert.IsTrue(raised);
+            Assert.AreEqual(second.Height, vm.Height);
+        }
+
+        [TestMethod]
+        public void RepeatModeButtonMarkedAsEditingWhenContentIsEditing()
+        {
+            _appSettings.SetupGet(m => m.RepeatModeButton).Returns(new RepeatModeButton());
+            var viewModel = new RepeatModeButtonViewModel(_appSettings.Object, _dialog.Object);
+
+            Assert.IsFalse(viewModel.RepeatTrackContent.IsEditing);
+            Assert.IsFalse(viewModel.IsEditing);
+
+            viewModel.RepeatTrackContent.Text = "test";
+
+            Assert.IsTrue(viewModel.RepeatTrackContent.IsEditing);
+            Assert.IsTrue(viewModel.IsEditing);
+        }
+
+        [TestMethod]
+        public void RepeatModeButtonSubscribesToAudioSource()
+        {
+            _appSettings.SetupGet(m => m.RepeatModeButton).Returns(new RepeatModeButton());
+            var viewModel = new RepeatModeButtonViewModel(_appSettings.Object, _dialog.Object);
+            var audiosourceMock = new Mock<IAudioSource>();
+            viewModel.AudioSource = audiosourceMock.Object;
+
+            audiosourceMock.Raise(m => m.RepeatModeChanged += null, null, RepeatMode.RepeatTrack);
+            Assert.AreEqual(RepeatMode.RepeatTrack, viewModel.RepeatMode);
+        }
+
+        [TestMethod]
+        public async Task RepeatModeButtonCyclesRepeatMode()
+        {
+            _appSettings.SetupGet(m => m.RepeatModeButton).Returns(new RepeatModeButton());
+            var viewModel = new RepeatModeButtonViewModel(_appSettings.Object, _dialog.Object);
+            var audiosourceMock = new Mock<IAudioSource>();
+            var repeatSequence = new[] {RepeatMode.RepeatContext, RepeatMode.RepeatTrack, RepeatMode.Off};
+            var index = 0;
+            audiosourceMock.Setup(m => m.SetRepeatModeAsync(It.IsAny<RepeatMode>()))
+                .Callback((RepeatMode mode) => Assert.AreEqual(repeatSequence[index++], mode))
+                .Returns(Task.CompletedTask);
+
+            viewModel.AudioSource = audiosourceMock.Object;
+
+            Assert.AreEqual(RepeatMode.Off, viewModel.RepeatMode);
+            await viewModel.CycleRepeatModeCommand.ExecuteAsync(null);
+            audiosourceMock.Raise(m => m.RepeatModeChanged += null, null, RepeatMode.RepeatContext);
+            await viewModel.CycleRepeatModeCommand.ExecuteAsync(null);
+            audiosourceMock.Raise(m => m.RepeatModeChanged += null, null, RepeatMode.RepeatTrack);
+            await viewModel.CycleRepeatModeCommand.ExecuteAsync(null);
         }
     }
 }

--- a/src/AudioBand/AudioBand.csproj
+++ b/src/AudioBand/AudioBand.csproj
@@ -71,6 +71,7 @@
     <Compile Include="AudioSource\AudioSourceProxy.cs" />
     <Compile Include="AudioSource\IAudioSourceManager.cs" />
     <Compile Include="AudioSource\IInternalAudioSource.cs" />
+    <Compile Include="Behaviors\Fallback.cs" />
     <Compile Include="Behaviors\RedirectScrolling.cs" />
     <Compile Include="Behaviors\SliderClickAndDrag.cs" />
     <Compile Include="Behaviors\TrackOffsetFix.cs" />
@@ -93,7 +94,9 @@
     <Compile Include="Models\AlbumArt.cs" />
     <Compile Include="Models\AlbumArtPopup.cs" />
     <Compile Include="Models\AudioBand.cs" />
+    <Compile Include="Models\ButtonContent.cs" />
     <Compile Include="Models\ButtonContentType.cs" />
+    <Compile Include="Models\ButtonModelBase.cs" />
     <Compile Include="Models\ModelBase.cs" />
     <Compile Include="Models\NextButton.cs" />
     <Compile Include="Models\PlaybackButtonBase.cs" />
@@ -101,6 +104,7 @@
     <Compile Include="Models\PreviousButton.cs" />
     <Compile Include="Models\ProgressBar.cs" />
     <Compile Include="Models\CustomLabel.cs" />
+    <Compile Include="Models\RepeatModeButton.cs" />
     <Compile Include="Models\ScrollBehavior.cs" />
     <Compile Include="Models\TextFadeEffect.cs" />
     <Compile Include="Models\TextOverflow.cs" />
@@ -141,6 +145,7 @@
     <Compile Include="Settings\Models\v3\ProfileExportV3.cs" />
     <Compile Include="Settings\Models\v3\ProfileV3.cs" />
     <Compile Include="Settings\Models\v3\SettingsV3.cs" />
+    <Compile Include="Settings\Profiles\SettingsV3Profile.cs" />
     <Compile Include="TaskbarHook.cs" />
     <Compile Include="ValueConverters\Converters.cs" />
     <Compile Include="ValueConverters\MultiConverters.cs" />
@@ -151,6 +156,8 @@
     <Compile Include="ViewModels\AudioBandToolbarViewModel.cs" />
     <Compile Include="ViewModels\AudioSourceSettingKeyValue.cs" />
     <Compile Include="ViewModels\AudioSourceSettingsCollectionViewModel.cs" />
+    <Compile Include="ViewModels\ButtonContentViewModel.cs" />
+    <Compile Include="ViewModels\ButtonViewModelBase.cs" />
     <Compile Include="ViewModels\ConfirmationDialogType.cs" />
     <Compile Include="ViewModels\CustomLabelsVM.cs" />
     <Compile Include="ViewModels\AboutVM.cs" />
@@ -160,6 +167,7 @@
     <Compile Include="ViewModels\PreviousButtonVM.cs" />
     <Compile Include="ViewModels\PropertyChangeBindingAttribute.cs" />
     <Compile Include="ViewModels\RenameProfileDialogVM.cs" />
+    <Compile Include="ViewModels\RepeatModeButtonViewModel.cs" />
     <Compile Include="ViewModels\SettingsWindowVM.cs" />
     <Compile Include="ViewModels\ViewModelBase.cs" />
     <Compile Include="ViewModels\ViewModelBase{TModel}.cs" />
@@ -312,6 +320,14 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Views\Settings\ButtonBaseTemplate.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\Settings\ButtonContentTemplate.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\Settings\ColorPicker.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -373,6 +389,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Resources\ToolbarProgressBarStyle.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\Settings\RepeatModeButtonSettingsView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/AudioBand/AudioBand.csproj
+++ b/src/AudioBand/AudioBand.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Behaviors\SliderClickAndDrag.cs" />
     <Compile Include="Behaviors\TrackOffsetFix.cs" />
     <Compile Include="Commands\AsyncRelayCommand.cs" />
+    <Compile Include="Commands\IAsyncCommand.cs" />
     <Compile Include="Commands\RelayCommand.cs" />
     <Compile Include="Commands\RelayCommand{T}.cs" />
     <Compile Include="CSDeskBand\CSDeskBand.cs" />

--- a/src/AudioBand/Behaviors/Fallback.cs
+++ b/src/AudioBand/Behaviors/Fallback.cs
@@ -1,0 +1,30 @@
+﻿using System.Windows;
+using System.Windows.Media;
+
+namespace AudioBand.Behaviors
+{
+    /// <summary>
+    /// Attached properties for binding fallback value binding.
+    /// </summary>
+    public static class Fallback
+    {
+        /// <summary>
+        /// Dependency property for a fallback image.
+        /// </summary>
+        public static readonly DependencyProperty FallbackImageSourceProperty = DependencyProperty.RegisterAttached("FallbackImageSource", typeof(ImageSource), typeof(Fallback));
+
+        /// <summary>
+        /// Gets the fallback image source.
+        /// </summary>
+        /// <param name="d">The object to get the fallback image from.</param>
+        /// <returns>The fallback image.</returns>
+        public static ImageSource GetFallbackImageSource(DependencyObject d) => (ImageSource)d.GetValue(FallbackImageSourceProperty);
+
+        /// <summary>
+        /// Sets the fallback image source.
+        /// </summary>
+        /// <param name="d">The object to set the fallback image on.</param>
+        /// <param name="value">The fallback image.</param>
+        public static void SetFallbackImageSource(DependencyObject d, ImageSource value) => d.SetValue(FallbackImageSourceProperty, value);
+    }
+}

--- a/src/AudioBand/Commands/AsyncRelayCommand.cs
+++ b/src/AudioBand/Commands/AsyncRelayCommand.cs
@@ -8,7 +8,7 @@ namespace AudioBand.Commands
     /// Basic async command.
     /// </summary>
     /// <typeparam name="T">Type of the command parameter.</typeparam>
-    public class AsyncRelayCommand<T> : ICommand
+    public class AsyncRelayCommand<T> : IAsyncCommand
     {
         private readonly Func<T, Task> _execute;
         private readonly Predicate<T> _canExecute;
@@ -49,7 +49,7 @@ namespace AudioBand.Commands
         /// <inheritdoc cref="ICommand.Execute"/>
         public async void Execute(object parameter)
         {
-            await _execute((T)parameter);
+            await ExecuteAsync(parameter);
         }
 
         /// <summary>

--- a/src/AudioBand/Commands/IAsyncCommand.cs
+++ b/src/AudioBand/Commands/IAsyncCommand.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace AudioBand.Commands
+{
+    /// <summary>
+    /// An async <see cref="ICommand"/>.
+    /// </summary>
+    public interface IAsyncCommand : ICommand
+    {
+        /// <summary>
+        /// Executes the command asynchronously.
+        /// </summary>
+        /// <param name="parameter">The command parameter.</param>
+        /// <returns>A task representing the result of the command.</returns>
+        Task ExecuteAsync(object parameter);
+    }
+}

--- a/src/AudioBand/Deskband.cs
+++ b/src/AudioBand/Deskband.cs
@@ -117,6 +117,7 @@ namespace AudioBand
                 _container.Register<ProgressBarVM>(Lifestyle.Singleton);
                 _container.Register<SettingsWindowVM>(Lifestyle.Singleton);
                 _container.Register<AudioSourceSettingsVM>(Lifestyle.Singleton);
+                _container.Register<RepeatModeButtonViewModel>(Lifestyle.Singleton);
 
                 _container.Verify();
             }

--- a/src/AudioBand/Models/ButtonContent.cs
+++ b/src/AudioBand/Models/ButtonContent.cs
@@ -1,0 +1,101 @@
+﻿using System.Windows.Media;
+
+namespace AudioBand.Models
+{
+    /// <summary>
+    /// Model for button content, including image or text settings.
+    /// </summary>
+    public class ButtonContent : ModelBase
+    {
+        private ButtonContentType _contentType = ButtonContentType.Text;
+        private string _imagePath;
+        private string _hoveredImagePath;
+        private string _clickedImagePath;
+        private string _fontFamily = "Segoe MDL2 Assets";
+        private string _text;
+        private Color _textColor = Colors.White;
+        private Color _hoveredTextColor = Colors.White;
+        private Color _clickedTextColor = Colors.White;
+
+        /// <summary>
+        /// Gets or sets the content type.
+        /// </summary>
+        public ButtonContentType ContentType
+        {
+            get => _contentType;
+            set => SetProperty(ref _contentType, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the image path.
+        /// </summary>
+        public string ImagePath
+        {
+            get => _imagePath;
+            set => SetProperty(ref _imagePath, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the hovered image path.
+        /// </summary>
+        public string HoveredImagePath
+        {
+            get => _hoveredImagePath;
+            set => SetProperty(ref _hoveredImagePath, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the clicked image path.
+        /// </summary>
+        public string ClickedImagePath
+        {
+            get => _clickedImagePath;
+            set => SetProperty(ref _clickedImagePath, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the font family.
+        /// </summary>
+        public string FontFamily
+        {
+            get => _fontFamily;
+            set => SetProperty(ref _fontFamily, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the text.
+        /// </summary>
+        public string Text
+        {
+            get => _text;
+            set => SetProperty(ref _text, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the text color.
+        /// </summary>
+        public Color TextColor
+        {
+            get => _textColor;
+            set => SetProperty(ref _textColor, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the text color when hovered.
+        /// </summary>
+        public Color HoveredTextColor
+        {
+            get => _hoveredTextColor;
+            set => SetProperty(ref _hoveredTextColor, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the text color when clicked.
+        /// </summary>
+        public Color ClickedTextColor
+        {
+            get => _clickedTextColor;
+            set => SetProperty(ref _clickedTextColor, value);
+        }
+    }
+}

--- a/src/AudioBand/Models/ButtonModelBase.cs
+++ b/src/AudioBand/Models/ButtonModelBase.cs
@@ -1,0 +1,91 @@
+﻿using System.Windows.Media;
+
+namespace AudioBand.Models
+{
+    /// <summary>
+    /// Base model for buttons.
+    /// </summary>
+    public class ButtonModelBase : ModelBase
+    {
+        private bool _isVisible = true;
+        private double _width;
+        private double _height;
+        private double _xPosition;
+        private double _yPosition;
+        private Color _backgroundColor = Colors.Transparent;
+        private Color _hoveredBackgroundColor = Color.FromArgb(25, 255, 255, 255);
+        private Color _clickedBackgroundColor = Color.FromArgb(15, 255, 255, 255);
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the button is visible.
+        /// </summary>
+        public bool IsVisible
+        {
+            get => _isVisible;
+            set => SetProperty(ref _isVisible, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the width of the button.
+        /// </summary>
+        public double Width
+        {
+            get => _width;
+            set => SetProperty(ref _width, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the height of the button.
+        /// </summary>
+        public double Height
+        {
+            get => _height;
+            set => SetProperty(ref _height, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the x position of the button.
+        /// </summary>
+        public double XPosition
+        {
+            get => _xPosition;
+            set => SetProperty(ref _xPosition, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the y position of the button.
+        /// </summary>
+        public double YPosition
+        {
+            get => _yPosition;
+            set => SetProperty(ref _yPosition, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the background color.
+        /// </summary>
+        public Color BackgroundColor
+        {
+            get => _backgroundColor;
+            set => SetProperty(ref _backgroundColor, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the background color when hovered.
+        /// </summary>
+        public Color HoveredBackgroundColor
+        {
+            get => _hoveredBackgroundColor;
+            set => SetProperty(ref _hoveredBackgroundColor, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the background color when clicked.
+        /// </summary>
+        public Color ClickedBackgroundColor
+        {
+            get => _clickedBackgroundColor;
+            set => SetProperty(ref _clickedBackgroundColor, value);
+        }
+    }
+}

--- a/src/AudioBand/Models/RepeatModeButton.cs
+++ b/src/AudioBand/Models/RepeatModeButton.cs
@@ -1,0 +1,54 @@
+﻿using System.Windows.Media;
+
+namespace AudioBand.Models
+{
+    /// <summary>
+    /// Model for the repeat mode button.
+    /// </summary>
+    public class RepeatModeButton : ButtonModelBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RepeatModeButton"/> class.
+        /// </summary>
+        public RepeatModeButton()
+        {
+            Width = 40;
+            Height = 15;
+            XPosition = 450;
+            YPosition = 3;
+        }
+
+        /// <summary>
+        /// Gets or sets the repeat off content.
+        /// </summary>
+        public ButtonContent RepeatOffContent { get; set; } = new ButtonContent
+        {
+            Text = "",
+            TextColor = Colors.DimGray,
+            HoveredTextColor = Colors.White,
+            ClickedTextColor = Colors.Gray,
+        };
+
+        /// <summary>
+        /// Gets or sets the repeat context content.
+        /// </summary>
+        public ButtonContent RepeatContextContent { get; set; } = new ButtonContent
+        {
+            Text = "",
+            TextColor = Colors.DodgerBlue,
+            HoveredTextColor = Colors.CornflowerBlue,
+            ClickedTextColor = Colors.RoyalBlue,
+        };
+
+        /// <summary>
+        /// Gets or sets the repeat track content.
+        /// </summary>
+        public ButtonContent RepeatTrackContent { get; set; } = new ButtonContent
+        {
+            Text = "",
+            TextColor = Colors.DodgerBlue,
+            HoveredTextColor = Colors.CornflowerBlue,
+            ClickedTextColor = Colors.RoyalBlue,
+        };
+    }
+}

--- a/src/AudioBand/Resources/Icons.xaml
+++ b/src/AudioBand/Resources/Icons.xaml
@@ -244,4 +244,22 @@
             </DrawingGroup>
         </DrawingImage.Drawing>
     </DrawingImage>
+    <DrawingImage x:Key="RepeatModeIcon">
+        <DrawingImage.Drawing>
+            <DrawingGroup ClipGeometry="M0,0 V256 H256 V0 H0 Z">
+                <DrawingGroup Opacity="1">
+                    <GeometryDrawing Geometry="F1 M256,256z M0,0z M142.19071,79.195957L178.96026,42.426407 142.19071,5.656854 M98.960267,42.426407L178.96026,42.426407 M34.618799,188.81415A90.992584,85.751953,0,0,1,14.894088,95.362512A90.992584,85.751953,0,0,1,98.960277,42.426411">
+                        <GeometryDrawing.Pen>
+                            <Pen Brush="{theme:ThemeResource SystemBaseHighColor}" Thickness="{StaticResource IconPenThickness}" StartLineCap="Flat" EndLineCap="Flat" LineJoin="Miter" />
+                        </GeometryDrawing.Pen>
+                    </GeometryDrawing>
+                    <GeometryDrawing Geometry="F1 M256,256z M0,0z M113.80929,176.80405L77.03974,213.5736 113.80929,250.34315 M157.03974,213.5736L77.03974,213.5736 M221.3812,67.185856A90.992584,85.751953,0,0,1,241.10591,160.6375A90.992584,85.751953,0,0,1,157.03973,213.5736">
+                        <GeometryDrawing.Pen>
+                            <Pen Brush="{theme:ThemeResource SystemBaseHighColor}" Thickness="{StaticResource IconPenThickness}" StartLineCap="Flat" EndLineCap="Flat" LineJoin="Miter" />
+                        </GeometryDrawing.Pen>
+                    </GeometryDrawing>
+                </DrawingGroup>
+            </DrawingGroup>
+        </DrawingImage.Drawing>
+    </DrawingImage>
 </ResourceDictionary>

--- a/src/AudioBand/Resources/Strings.xaml
+++ b/src/AudioBand/Resources/Strings.xaml
@@ -47,6 +47,17 @@
     <sys:String x:Key="PlaybackButtonTextDescription">Button text</sys:String>
     <sys:String x:Key="ImageSectionText">Image</sys:String>
 
+    <!-- Button content settings -->
+    <sys:String x:Key="ButtonContentSectionText">Button content</sys:String>
+    <sys:String x:Key="ButtonContentTypeDescription">Select the content type</sys:String>
+    <sys:String x:Key="ButtonFontFamilyDescription">Select the font family for the text</sys:String>
+    <sys:String x:Key="ButtonTextDescription">Button text</sys:String>
+
+    <!-- Repeat mode button settings -->
+    <sys:String x:Key="RepeatModeButtonOffContentSectionText">Repeat off button content</sys:String>
+    <sys:String x:Key="RepeatModeButtonContextContentSectionText">Repeat on button content</sys:String>
+    <sys:String x:Key="RepeatModeButtonTrackContentSectionText">Repeat track button content</sys:String>
+
     <!-- Custom text label settings -->
     <sys:String x:Key="CustomLabelNameDescription">Choose a name for the label</sys:String>
     <sys:String x:Key="CustomLabelFontFamilyDescription">Font Family</sys:String>
@@ -86,6 +97,7 @@ Using style and color : {*artist:#a9a9a9}</sys:String>
     <sys:String x:Key="PlayPauseButtonTab">Play/Pause Button</sys:String>
     <sys:String x:Key="PrevButtonTab">Previous Track Button</sys:String>
     <sys:String x:Key="NextButtonTab">Next Track Button</sys:String>
+    <sys:String x:Key="RepeatModeButtonTab">Repeat Mode Button</sys:String>
     <sys:String x:Key="ProgressBarTab">Progress Bar</sys:String>
     <sys:String x:Key="CustomLabelsTab">Text Labels</sys:String>
     <sys:String x:Key="AlbumArtTab">Album Art</sys:String>

--- a/src/AudioBand/Resources/ToolbarButtonStyles.xaml
+++ b/src/AudioBand/Resources/ToolbarButtonStyles.xaml
@@ -6,6 +6,8 @@
                     xmlns:sys="clr-namespace:System;assembly=mscorlib"
                     xmlns:converters="clr-namespace:AudioBand.ValueConverters"
                     xmlns:models="clr-namespace:AudioBand.Models"
+                    xmlns:behaviors="clr-namespace:AudioBand.Behaviors"
+                    xmlns:audioSource="clr-namespace:AudioBand.AudioSource;assembly=AudioBand.AudioSource"
                     mc:Ignorable="d">
     <Pen x:Key="ButtonImagePen" Brush="#FFFFFF" Thickness="30" StartLineCap="Flat" EndLineCap="Flat" LineJoin="Miter" />
     <DrawingImage x:Key="PauseButtonDefault">
@@ -49,6 +51,54 @@
                     <DrawingGroup Transform="0.85326308,0,0,-1.0497388,38.884699,262.36656">
                         <GeometryDrawing Geometry="F1 M256,256z M0,0z M60.365532,128.00001L153.18276,74.411943 245.99999,20.823889 246,128 246,235.17611 153.18276,181.58806z"
                                          Pen="{StaticResource ButtonImagePen}"/>
+                    </DrawingGroup>
+                </DrawingGroup>
+            </DrawingGroup>
+        </DrawingImage.Drawing>
+    </DrawingImage>
+    <DrawingImage x:Key="RepeatOffDefault">
+        <DrawingImage.Drawing>
+            <DrawingGroup ClipGeometry="M0,0 V256 H256 V0 H0 Z">
+                <DrawingGroup Opacity="1">
+                    <GeometryDrawing Geometry="F1 M256,256z M0,0z M142.19071,79.195957L178.96026,42.426407 142.19071,5.656854 M98.960267,42.426407L178.96026,42.426407 M34.618799,188.81415A90.992584,85.751953,0,0,1,14.894088,95.362512A90.992584,85.751953,0,0,1,98.960277,42.426411"
+                                     Pen="{StaticResource ButtonImagePen}"/>
+                    <GeometryDrawing Geometry="F1 M256,256z M0,0z M113.80929,176.80405L77.03974,213.5736 113.80929,250.34315 M157.03974,213.5736L77.03974,213.5736 M221.3812,67.185856A90.992584,85.751953,0,0,1,241.10591,160.6375A90.992584,85.751953,0,0,1,157.03973,213.5736"
+                                     Pen="{StaticResource ButtonImagePen}"/>
+                </DrawingGroup>
+            </DrawingGroup>
+        </DrawingImage.Drawing>
+    </DrawingImage>
+    <DrawingImage x:Key="RepeatContextDefault">
+        <DrawingImage.Drawing>
+            <DrawingGroup ClipGeometry="M0,0 V256 H256 V0 H0 Z">
+                <DrawingGroup Opacity="1">
+                    <GeometryDrawing Pen="{StaticResource ButtonImagePen}" Geometry="F1 M256,256z M0,0z M142.19071,79.195957L178.96026,42.426407 142.19071,5.656854 M98.960267,42.426407L178.96026,42.426407 M34.618799,188.81415A90.992584,85.751953,0,0,1,14.894088,95.362512A90.992584,85.751953,0,0,1,98.960277,42.426411"/>
+                    <GeometryDrawing Pen="{StaticResource ButtonImagePen}" Geometry="F1 M256,256z M0,0z M113.80929,176.80405L77.03974,213.5736 113.80929,250.34315 M157.03974,213.5736L77.03974,213.5736 M221.3812,67.185856A90.992584,85.751953,0,0,1,241.10591,160.6375A90.992584,85.751953,0,0,1,157.03973,213.5736"/>
+                    <GeometryDrawing Pen="{StaticResource ButtonImagePen}">
+                        <GeometryDrawing.Geometry>
+                            <EllipseGeometry RadiusX="22" RadiusY="22" Center="128,128" />
+                        </GeometryDrawing.Geometry>
+                    </GeometryDrawing>
+                </DrawingGroup>
+            </DrawingGroup>
+        </DrawingImage.Drawing>
+    </DrawingImage>
+    <DrawingImage x:Key="RepeatOneDefault">
+        <DrawingImage.Drawing>
+            <DrawingGroup ClipGeometry="M0,0 V256 H256 V0 H0 Z">
+                <DrawingGroup Opacity="1">
+                    <GeometryDrawing Pen="{StaticResource ButtonImagePen}" Geometry="F1 M256,256z M0,0z M142.19071,79.195957L178.96026,42.426407 142.19071,5.656854 M98.960267,42.426407L178.96026,42.426407 M34.618799,188.81415A90.992584,85.751953,0,0,1,14.894088,95.362512A90.992584,85.751953,0,0,1,98.960277,42.426411"/>
+                    <GeometryDrawing Pen="{StaticResource ButtonImagePen}" Geometry="F1 M256,256z M0,0z M113.80929,176.80405L77.03974,213.5736 113.80929,250.34315 M157.03974,213.5736L77.03974,213.5736 M221.3812,67.185856A90.992584,85.751953,0,0,1,241.10591,160.6375A90.992584,85.751953,0,0,1,157.03973,213.5736"/>
+                    <DrawingGroup>
+                        <GlyphRunDrawing ForegroundBrush="White">
+                            <GlyphRunDrawing.GlyphRun>
+                                <GlyphRun PixelsPerDip="1" BaselineOrigin="94.079124,170.94922" FontRenderingEmSize="120" BidiLevel="0" IsSideways="False" CaretStops="1 1" ClusterMap="0" Characters="1" GlyphIndices="20" AdvanceWidths="64.6866666666667" GlyphOffsets="0,0" Language="en-us">
+                                    <GlyphRun.GlyphTypeface>
+                                        <GlyphTypeface FontUri="C:\WINDOWS\FONTS\SEGOEUI.TTF" StyleSimulations="None" />
+                                    </GlyphRun.GlyphTypeface>
+                                </GlyphRun>
+                            </GlyphRunDrawing.GlyphRun>
+                        </GlyphRunDrawing>
                     </DrawingGroup>
                 </DrawingGroup>
             </DrawingGroup>
@@ -309,6 +359,96 @@
                         </Viewbox>
                     </Setter.Value>
                 </Setter>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+    <DataTemplate x:Key="ToolbarButtonContentImageTemplate" DataType="viewmodels:ButtonContentViewModel">
+        <Viewbox RenderOptions.BitmapScalingMode="Fant" Margin="1">
+            <Image x:Name="Image">
+                <Image.Source>
+                    <MultiBinding Converter="{x:Static converters:MultiConverters.PathToImageSource}">
+                        <Binding Path="ImagePath"/>
+                        <Binding RelativeSource="{RelativeSource AncestorType={x:Type Button}}" Path="(behaviors:Fallback.FallbackImageSource)"/>
+                    </MultiBinding>
+                </Image.Source>
+            </Image>
+        </Viewbox>
+        <DataTemplate.Triggers>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type Button}}, Path=IsMouseOver}" Value="True">
+                <Setter TargetName="Image" Property="Source">
+                    <Setter.Value>
+                        <MultiBinding Converter="{x:Static converters:MultiConverters.PathToImageSource}">
+                            <Binding Path="HoveredImagePath"/>
+                            <Binding RelativeSource="{RelativeSource AncestorType={x:Type Button}}" Path="(behaviors:Fallback.FallbackImageSource)"/>
+                        </MultiBinding>
+                    </Setter.Value>
+                </Setter>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type Button}}, Path=IsPressed}" Value="True">
+                <Setter TargetName="Image" Property="Source">
+                    <Setter.Value>
+                        <MultiBinding Converter="{x:Static converters:MultiConverters.PathToImageSource}">
+                            <Binding Path="ClickedImagePath"/>
+                            <Binding RelativeSource="{RelativeSource AncestorType={x:Type Button}}" Path="(behaviors:Fallback.FallbackImageSource)"/>
+                        </MultiBinding>
+                    </Setter.Value>
+                </Setter>
+            </DataTrigger>
+        </DataTemplate.Triggers>
+    </DataTemplate>
+    <DataTemplate x:Key="ToolbarButtonContentTextTemplate" DataType="viewmodels:ButtonContentViewModel">
+        <Viewbox>
+            <TextBlock x:Name="Text" Text="{Binding Text}" FontFamily="{Binding FontFamily}" 
+                       Foreground="{Binding TextColor, Converter={x:Static converters:Converters.ColorToBrush}}" FontSize="72"/>
+        </Viewbox>
+        <DataTemplate.Triggers>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type Button}}, Path=IsMouseOver}" Value="True">
+                <Setter TargetName="Text" Property="Foreground" Value="{Binding HoveredTextColor, Converter={x:Static converters:Converters.ColorToBrush}}"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type Button}}, Path=IsPressed}" Value="True">
+                <Setter TargetName="Text" Property="Foreground" Value="{Binding ClickedTextColor, Converter={x:Static converters:Converters.ColorToBrush}}"/>
+            </DataTrigger>
+        </DataTemplate.Triggers>
+    </DataTemplate>
+    <ControlTemplate x:Key="ToolbarButtonControlTemplate" TargetType="{x:Type Button}">
+        <Grid>
+            <Border x:Name="ButtonBackground" Background="{Binding BackgroundColor, Converter={x:Static converters:Converters.ColorToBrush}}"/>
+            <ContentPresenter x:Name="ButtonContent" Content="{TemplateBinding Content}"
+                              HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="ButtonBackground" Property="Background" Value="{Binding HoveredBackgroundColor, Converter={x:Static converters:Converters.ColorToBrush}}"/>
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter TargetName="ButtonBackground" Property="Background" Value="{Binding ClickedBackgroundColor, Converter={x:Static converters:Converters.ColorToBrush}}"/>
+            </Trigger>
+            <DataTrigger Binding="{Binding ElementName=ButtonContent, Path=Content.(viewmodels:ButtonContentViewModel.ContentType)}" Value="{x:Static models:ButtonContentType.Text}">
+                <Setter TargetName="ButtonContent" Property="ContentTemplate" Value="{StaticResource ToolbarButtonContentTextTemplate}"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding ElementName=ButtonContent, Path=Content.(viewmodels:ButtonContentViewModel.ContentType)}" Value="{x:Static models:ButtonContentType.Image}">
+                <Setter TargetName="ButtonContent" Property="ContentTemplate" Value="{StaticResource ToolbarButtonContentImageTemplate}"/>
+            </DataTrigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+    <Style x:Key="ToolbarRepeatModeButtonStyle" TargetType="{x:Type Button}">
+        <d:Style.DataContext>
+            <x:Type Type="viewmodels:RepeatModeButtonViewModel"/>
+        </d:Style.DataContext>
+        <Setter Property="OverridesDefaultStyle" Value="True"/>
+        <Setter Property="Template" Value="{StaticResource ToolbarButtonControlTemplate}"/>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding RepeatMode}" Value="{x:Static audioSource:RepeatMode.Off}">
+                <Setter Property="Content" Value="{Binding RepeatOffContent}"/>
+                <Setter Property="behaviors:Fallback.FallbackImageSource" Value="{StaticResource RepeatOffDefault}"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RepeatMode}" Value="{x:Static audioSource:RepeatMode.RepeatContext}">
+                <Setter Property="Content" Value="{Binding RepeatContextContent}"/>
+                <Setter Property="behaviors:Fallback.FallbackImageSource" Value="{StaticResource RepeatContextDefault}"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding RepeatMode}" Value="{x:Static audioSource:RepeatMode.RepeatTrack}">
+                <Setter Property="Content" Value="{Binding RepeatTrackContent}"/>
+                <Setter Property="behaviors:Fallback.FallbackImageSource" Value="{StaticResource RepeatOneDefault}"/>
             </DataTrigger>
         </Style.Triggers>
     </Style>

--- a/src/AudioBand/Settings/IAppSettings.cs
+++ b/src/AudioBand/Settings/IAppSettings.cs
@@ -55,6 +55,11 @@ namespace AudioBand.Settings
         PlayPauseButton PlayPauseButton { get; }
 
         /// <summary>
+        /// Gets the repeat mode button model.
+        /// </summary>
+        RepeatModeButton RepeatModeButton { get; }
+
+        /// <summary>
         /// Gets the saved progress bar model.
         /// </summary>
         ProgressBar ProgressBar { get; }

--- a/src/AudioBand/Settings/Migrations/V2ToV3.cs
+++ b/src/AudioBand/Settings/Migrations/V2ToV3.cs
@@ -88,7 +88,8 @@ namespace AudioBand.Settings.Migrations
                     .ForMember(dest => dest.NextButtonSettings, opt => opt.MapFrom(source => source.NextButtonSettings))
                     .ForMember(dest => dest.PlayPauseButtonSettings, opt => opt.MapFrom(source => source.PlayPauseButtonSettings))
                     .ForMember(dest => dest.PreviousButtonSettings, opt => opt.MapFrom(source => source.PreviousButtonSettings))
-                    .ForMember(dest => dest.ProgressBarSettings, opt => opt.MapFrom(source => source.ProgressBarSettings));
+                    .ForMember(dest => dest.ProgressBarSettings, opt => opt.MapFrom(source => source.ProgressBarSettings))
+                    .ForMember(dest => dest.RepeatModeButtonSettings, opt => opt.MapFrom(source => new RepeatModeButton()));
                 cfg.CreateMap<Models.V2.Settings, Dictionary<string, ProfileV3>>().ConvertUsing<ProfilesConverter>();
                 cfg.CreateMap<Models.V2.Settings, SettingsV3>()
                     .ForMember(dest => dest.Version, opt => opt.Ignore())

--- a/src/AudioBand/Settings/Models/v3/ProfileV3.cs
+++ b/src/AudioBand/Settings/Models/v3/ProfileV3.cs
@@ -29,6 +29,11 @@ namespace AudioBand.Settings.Models.v3
         public NextButton NextButtonSettings { get; set; }
 
         /// <summary>
+        /// Gets or sets the repeat mode button settings.
+        /// </summary>
+        public RepeatModeButton RepeatModeButtonSettings { get; set; }
+
+        /// <summary>
         /// Gets or sets the progressbar settings.
         /// </summary>
         public ProgressBar ProgressBarSettings { get; set; }

--- a/src/AudioBand/Settings/Profiles/SettingsV3Profile.cs
+++ b/src/AudioBand/Settings/Profiles/SettingsV3Profile.cs
@@ -1,0 +1,22 @@
+﻿using AudioBand.Models;
+using AudioBand.Settings.Models.v3;
+using AutoMapper;
+
+namespace AudioBand.Settings.Profiles
+{
+    /// <summary>
+    /// Fixes new values that are added to the configuration.
+    /// </summary>
+    internal class SettingsV3Profile : Profile
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SettingsV3Profile"/> class.
+        /// </summary>
+        public SettingsV3Profile()
+        {
+            CreateMap<SettingsV3, SettingsV3>();
+            CreateMap<ProfileV3, ProfileV3>()
+                .ForMember(dest => dest.RepeatModeButtonSettings, opt => opt.NullSubstitute(new RepeatModeButton())); // Repeat mode button was added after
+        }
+    }
+}

--- a/src/AudioBand/ValueConverters/MultiConverters.cs
+++ b/src/AudioBand/ValueConverters/MultiConverters.cs
@@ -19,5 +19,10 @@
         /// Gets a <see cref="PointConverter"/>.
         /// </summary>
         public static PointConverter Point { get; } = new PointConverter();
+
+        /// <summary>
+        /// Gets a <see cref="PathToImageSource"/> multi converter.
+        /// </summary>
+        public static PathToImageSourceConverter PathToImageSource { get; } = new PathToImageSourceConverter();
     }
 }

--- a/src/AudioBand/ValueConverters/PathToImageSourceConverter.cs
+++ b/src/AudioBand/ValueConverters/PathToImageSourceConverter.cs
@@ -10,10 +10,10 @@ using SharpVectors.Renderers.Wpf;
 namespace AudioBand.ValueConverters
 {
     /// <summary>
-    /// Converts a path to an image source.
+    /// Converts a path to an image source. Multivalue version allows the fallback to be bound.
     /// </summary>
     [ValueConversion(typeof(string), typeof(ImageSource))]
-    public class PathToImageSourceConverter : IValueConverter
+    public class PathToImageSourceConverter : IValueConverter, IMultiValueConverter
     {
         /// <inheritdoc />
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
@@ -48,6 +48,18 @@ namespace AudioBand.ValueConverters
 
         /// <inheritdoc />
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            return Convert(values[0], targetType, parameter, culture) ?? values[1];
+        }
+
+        /// <inheritdoc />
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/src/AudioBand/ViewModels/AudioBandToolbarViewModel.cs
+++ b/src/AudioBand/ViewModels/AudioBandToolbarViewModel.cs
@@ -160,6 +160,7 @@ namespace AudioBand.ViewModels
             ViewModels.PreviousButtonVM.AudioSource = audioSource;
             ViewModels.PlayPauseButtonVM.AudioSource = audioSource;
             ViewModels.ProgressBarVM.AudioSource = audioSource;
+            ViewModels.RepeatModeButtonViewModel.AudioSource = audioSource;
             foreach (var customLabelVm in ViewModels.CustomLabelsVM.CustomLabels)
             {
                 customLabelVm.AudioSource = audioSource;

--- a/src/AudioBand/ViewModels/ButtonContentViewModel.cs
+++ b/src/AudioBand/ViewModels/ButtonContentViewModel.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Media;
+using AudioBand.Extensions;
+using AudioBand.Models;
+
+namespace AudioBand.ViewModels
+{
+    /// <summary>
+    /// View model for button content.
+    /// </summary>
+    public class ButtonContentViewModel : ViewModelBase<ButtonContent>
+    {
+        private readonly ButtonContent _resetContent;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ButtonContentViewModel"/> class.
+        /// </summary>
+        /// <param name="model">The button content model.</param>
+        /// <param name="resetContent">The state used for resetting.</param>
+        /// <param name="dialogService">The dialog service.</param>
+        public ButtonContentViewModel(ButtonContent model, ButtonContent resetContent, IDialogService dialogService)
+            : base(model)
+        {
+            _resetContent = resetContent;
+            DialogService = dialogService;
+        }
+
+        /// <summary>
+        /// Gets the button content types.
+        /// </summary>
+        public static IEnumerable<EnumDescriptor<ButtonContentType>> ButtonContentTypes { get; } = typeof(ButtonContentType).GetEnumDescriptors<ButtonContentType>();
+
+        /// <summary>
+        /// Gets or sets the content type.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonContent.ContentType))]
+        public ButtonContentType ContentType
+        {
+            get => Model.ContentType;
+            set => SetProperty(nameof(Model.ContentType), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the image path.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonContent.ImagePath))]
+        public string ImagePath
+        {
+            get => Model.ImagePath;
+            set => SetProperty(nameof(Model.ImagePath), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the path of the image when hovered.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonContent.HoveredImagePath))]
+        public string HoveredImagePath
+        {
+            get => Model.HoveredImagePath;
+            set => SetProperty(nameof(Model.HoveredImagePath), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the path of the image when clicked.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonContent.ClickedImagePath))]
+        public string ClickedImagePath
+        {
+            get => Model.ClickedImagePath;
+            set => SetProperty(nameof(Model.ClickedImagePath), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the font family for the text.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonContent.FontFamily))]
+        public string FontFamily
+        {
+            get => Model.FontFamily;
+            set => SetProperty(nameof(Model.FontFamily), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the text.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonContent.Text))]
+        public string Text
+        {
+            get => Model.Text;
+            set => SetProperty(nameof(Model.Text), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the text color.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonContent.TextColor))]
+        public Color TextColor
+        {
+            get => Model.TextColor;
+            set => SetProperty(nameof(Model.TextColor), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the text color when hovered.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonContent.HoveredTextColor))]
+        public Color HoveredTextColor
+        {
+            get => Model.HoveredTextColor;
+            set => SetProperty(nameof(Model.HoveredTextColor), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the text color when clicked.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonContent.ClickedTextColor))]
+        public Color ClickedTextColor
+        {
+            get => Model.ClickedTextColor;
+            set => SetProperty(nameof(Model.ClickedTextColor), value);
+        }
+
+        /// <summary>
+        /// Gets the dialog service.
+        /// </summary>
+        public IDialogService DialogService { get; }
+
+        /// <inheritdoc />
+        protected override void OnReset()
+        {
+            BeginEdit();
+            ResetObject(_resetContent, Model);
+        }
+    }
+}

--- a/src/AudioBand/ViewModels/ButtonViewModelBase.cs
+++ b/src/AudioBand/ViewModels/ButtonViewModelBase.cs
@@ -1,0 +1,179 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows.Media;
+using AudioBand.Models;
+
+namespace AudioBand.ViewModels
+{
+    /// <summary>
+    /// Base view model for buttons.
+    /// </summary>
+    /// <typeparam name="TButton">The button model.</typeparam>
+    public class ButtonViewModelBase<TButton> : ViewModelBase<TButton>
+        where TButton : ButtonModelBase, new()
+    {
+        private readonly List<ButtonContentViewModel> _contentViewModels = new List<ButtonContentViewModel>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ButtonViewModelBase{TButton}"/> class.
+        /// </summary>
+        /// <param name="model">The button model.</param>
+        /// <param name="dialogService">The dialog service to use.</param>
+        public ButtonViewModelBase(TButton model, IDialogService dialogService)
+            : base(model)
+        {
+            DialogService = dialogService;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the button is visible.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonModelBase.IsVisible))]
+        public bool IsVisible
+        {
+            get => Model.IsVisible;
+            set => SetProperty(nameof(Model.IsVisible), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the width.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonModelBase.Width))]
+        public double Width
+        {
+            get => Model.Width;
+            set => SetProperty(nameof(Model.Width), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the height.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonModelBase.Height))]
+        public double Height
+        {
+            get => Model.Height;
+            set => SetProperty(nameof(Model.Height), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the x position.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonModelBase.XPosition))]
+        public double XPosition
+        {
+            get => Model.XPosition;
+            set => SetProperty(nameof(Model.XPosition), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the y position.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonModelBase.YPosition))]
+        public double YPosition
+        {
+            get => Model.YPosition;
+            set => SetProperty(nameof(Model.YPosition), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the background color.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonModelBase.BackgroundColor))]
+        public Color BackgroundColor
+        {
+            get => Model.BackgroundColor;
+            set => SetProperty(nameof(Model.BackgroundColor), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the background color when hovered.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonModelBase.HoveredBackgroundColor))]
+        public Color HoveredBackgroundColor
+        {
+            get => Model.HoveredBackgroundColor;
+            set => SetProperty(nameof(Model.HoveredBackgroundColor), value);
+        }
+
+        /// <summary>
+        /// Gets or sets the background color when clicked.
+        /// </summary>
+        [PropertyChangeBinding(nameof(ButtonModelBase.ClickedBackgroundColor))]
+        public Color ClickedBackgroundColor
+        {
+            get => Model.ClickedBackgroundColor;
+            set => SetProperty(nameof(Model.ClickedBackgroundColor), value);
+        }
+
+        /// <summary>
+        /// Gets the dialog service.
+        /// </summary>
+        public IDialogService DialogService { get; }
+
+        /// <summary>
+        /// Track the button content view models edit state.
+        /// </summary>
+        /// <param name="viewModel">The button content view model.</param>
+        protected void TrackContentViewModel(ButtonContentViewModel viewModel)
+        {
+            Debug.Assert(!_contentViewModels.Contains(viewModel), "Already tracked this view model");
+            _contentViewModels.Add(viewModel);
+            viewModel.PropertyChanged += ButtonContentViewModelOnPropertyChanged;
+        }
+
+        /// <inheritdoc />
+        protected override void OnCancelEdit()
+        {
+            base.OnCancelEdit();
+            foreach (var buttonContentViewModel in _contentViewModels)
+            {
+                buttonContentViewModel.CancelEdit();
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnEndEdit()
+        {
+            base.OnEndEdit();
+            foreach (var buttonContentViewModel in _contentViewModels)
+            {
+                buttonContentViewModel.EndEdit();
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnBeginEdit()
+        {
+            base.OnBeginEdit();
+            foreach (var buttonContentViewModel in _contentViewModels)
+            {
+                buttonContentViewModel.BeginEdit();
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnReset()
+        {
+            base.OnReset();
+            foreach (var buttonContentViewModel in _contentViewModels)
+            {
+                buttonContentViewModel.Reset();
+            }
+        }
+
+        private void ButtonContentViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(IsEditing))
+            {
+                return;
+            }
+
+            var vm = (ButtonContentViewModel)sender;
+            if (vm.IsEditing)
+            {
+                BeginEdit();
+            }
+        }
+    }
+}

--- a/src/AudioBand/ViewModels/IViewModelContainer.cs
+++ b/src/AudioBand/ViewModels/IViewModelContainer.cs
@@ -41,6 +41,11 @@
         PreviousButtonVM PreviousButtonVM { get; }
 
         /// <summary>
+        /// Gets the view model for the repeat mode button.
+        /// </summary>
+        RepeatModeButtonViewModel RepeatModeButtonViewModel { get; }
+
+        /// <summary>
         /// Gets the view model for the progress bar.
         /// </summary>
         ProgressBarVM ProgressBarVM { get; }

--- a/src/AudioBand/ViewModels/RepeatModeButtonViewModel.cs
+++ b/src/AudioBand/ViewModels/RepeatModeButtonViewModel.cs
@@ -58,7 +58,7 @@ namespace AudioBand.ViewModels
         /// <summary>
         /// Gets the command to change the repeat mode.
         /// </summary>
-        public ICommand CycleRepeatModeCommand { get; }
+        public IAsyncCommand CycleRepeatModeCommand { get; }
 
         /// <summary>
         /// Gets the current repeat mode.

--- a/src/AudioBand/ViewModels/RepeatModeButtonViewModel.cs
+++ b/src/AudioBand/ViewModels/RepeatModeButtonViewModel.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using AudioBand.AudioSource;
+using AudioBand.Commands;
+using AudioBand.Models;
+using AudioBand.Settings;
+
+namespace AudioBand.ViewModels
+{
+    /// <summary>
+    /// View model for the repeat mode button.
+    /// </summary>
+    public class RepeatModeButtonViewModel : ButtonViewModelBase<RepeatModeButton>
+    {
+        private readonly IAppSettings _appSettings;
+        private IAudioSource _audioSource;
+        private RepeatMode _repeatMode;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RepeatModeButtonViewModel"/> class.
+        /// </summary>
+        /// <param name="appSettings">The app settings.</param>
+        /// <param name="dialogService">The dialog service.</param>
+        public RepeatModeButtonViewModel(IAppSettings appSettings, IDialogService dialogService)
+            : base(appSettings.RepeatModeButton, dialogService)
+        {
+            _appSettings = appSettings;
+            _appSettings.ProfileChanged += AppSettingsOnProfileChanged;
+
+            var resetState = new RepeatModeButton();
+            RepeatOffContent = new ButtonContentViewModel(Model.RepeatOffContent, resetState.RepeatOffContent, dialogService);
+            RepeatContextContent = new ButtonContentViewModel(Model.RepeatContextContent, resetState.RepeatContextContent, dialogService);
+            RepeatTrackContent = new ButtonContentViewModel(Model.RepeatTrackContent, resetState.RepeatTrackContent, dialogService);
+            CycleRepeatModeCommand = new AsyncRelayCommand<object>(CycleRepeatModeCommandOnExecute);
+
+            TrackContentViewModel(RepeatOffContent);
+            TrackContentViewModel(RepeatContextContent);
+            TrackContentViewModel(RepeatTrackContent);
+        }
+
+        /// <summary>
+        /// Gets the button content when repeat is off.
+        /// </summary>
+        public ButtonContentViewModel RepeatOffContent { get; }
+
+        /// <summary>
+        /// Gets the button content when repeat is on.
+        /// </summary>
+        public ButtonContentViewModel RepeatContextContent { get; }
+
+        /// <summary>
+        /// Gets the button content when repeat is on for the track.
+        /// </summary>
+        public ButtonContentViewModel RepeatTrackContent { get; }
+
+        /// <summary>
+        /// Gets the command to change the repeat mode.
+        /// </summary>
+        public ICommand CycleRepeatModeCommand { get; }
+
+        /// <summary>
+        /// Gets the current repeat mode.
+        /// </summary>
+        public RepeatMode RepeatMode
+        {
+            get => _repeatMode;
+            private set => SetProperty(ref _repeatMode, value, false);
+        }
+
+        /// <summary>
+        /// Sets the audio source.
+        /// </summary>
+        public IAudioSource AudioSource
+        {
+            set => UpdateAudioSource(value);
+        }
+
+        private void UpdateAudioSource(IAudioSource audioSource)
+        {
+            if (_audioSource != null)
+            {
+                _audioSource.RepeatModeChanged -= AudioSourceOnRepeatModeChanged;
+            }
+
+            _audioSource = audioSource;
+            if (_audioSource == null)
+            {
+                RepeatMode = RepeatMode.Off;
+                return;
+            }
+
+            _audioSource.RepeatModeChanged += AudioSourceOnRepeatModeChanged;
+        }
+
+        private void AudioSourceOnRepeatModeChanged(object sender, RepeatMode e)
+        {
+            RepeatMode = e;
+        }
+
+        private void AppSettingsOnProfileChanged(object sender, EventArgs e)
+        {
+            Debug.Assert(IsEditing == false, "Should not be editing");
+            ReplaceModel(_appSettings.RepeatModeButton);
+        }
+
+        private async Task CycleRepeatModeCommandOnExecute(object obj)
+        {
+            var nextRepeatMode = RepeatMode;
+            switch (RepeatMode)
+            {
+                case RepeatMode.Off:
+                    nextRepeatMode = RepeatMode.RepeatContext;
+                    break;
+                case RepeatMode.RepeatContext:
+                    nextRepeatMode = RepeatMode.RepeatTrack;
+                    break;
+                case RepeatMode.RepeatTrack:
+                    nextRepeatMode = RepeatMode.Off;
+                    break;
+            }
+
+            await _audioSource.SetRepeatModeAsync(nextRepeatMode);
+        }
+    }
+}

--- a/src/AudioBand/ViewModels/ViewModelBase.cs
+++ b/src/AudioBand/ViewModels/ViewModelBase.cs
@@ -186,6 +186,18 @@ namespace AudioBand.ViewModels
         }
 
         /// <summary>
+        /// Resets an object to its default state using the given state.
+        /// </summary>
+        /// <typeparam name="T">Object type.</typeparam>
+        /// <param name="initialState">The objects initial state.</param>
+        /// <param name="obj">Object to reset.</param>
+        protected void ResetObject<T>(T initialState, T obj)
+        {
+            var mapper = new MapperConfiguration(cfg => cfg.CreateMap<T, T>()).CreateMapper();
+            mapper.Map<T, T>(initialState, obj);
+        }
+
+        /// <summary>
         /// Called when <see cref="Reset"/> is called.
         /// </summary>
         protected virtual void OnReset() { }

--- a/src/AudioBand/ViewModels/ViewModelContainer.cs
+++ b/src/AudioBand/ViewModels/ViewModelContainer.cs
@@ -14,6 +14,7 @@
         /// <param name="customLabelsVm">Custom labels view model.</param>
         /// <param name="nextButtonVm">Next button view model.</param>
         /// <param name="playPauseButtonVm">Play pause button view model.</param>
+        /// <param name="repeatModeButtonViewModel">Repeat mode button view model.</param>
         /// <param name="previousButtonVm">Previous button view model.</param>
         /// <param name="progressBarVm">Progress bar view model.</param>
         /// <param name="audioSourceSettingsVm">Audio source settings view model.</param>
@@ -24,6 +25,7 @@
             CustomLabelsVM customLabelsVm,
             NextButtonVM nextButtonVm,
             PlayPauseButtonVM playPauseButtonVm,
+            RepeatModeButtonViewModel repeatModeButtonViewModel,
             PreviousButtonVM previousButtonVm,
             ProgressBarVM progressBarVm,
             AudioSourceSettingsVM audioSourceSettingsVm)
@@ -34,6 +36,7 @@
             CustomLabelsVM = customLabelsVm;
             NextButtonVM = nextButtonVm;
             PlayPauseButtonVM = playPauseButtonVm;
+            RepeatModeButtonViewModel = repeatModeButtonViewModel;
             PreviousButtonVM = previousButtonVm;
             ProgressBarVM = progressBarVm;
             AudioSourceSettingsVm = audioSourceSettingsVm;
@@ -59,6 +62,9 @@
 
         /// <inheritdoc />
         public PreviousButtonVM PreviousButtonVM { get; }
+
+        /// <inheritdoc />
+        public RepeatModeButtonViewModel RepeatModeButtonViewModel { get; }
 
         /// <inheritdoc />
         public ProgressBarVM ProgressBarVM { get; }

--- a/src/AudioBand/Views/AudioBandToolbar.xaml
+++ b/src/AudioBand/Views/AudioBandToolbar.xaml
@@ -201,6 +201,13 @@
                 Canvas.Left="{Binding XPosition}" Canvas.Top="{Binding YPosition}"
                 Style="{StaticResource ToolbarPreviousButtonStyle}"
                 Command="{Binding PreviousTrackCommand}"/>
+        <Button x:Name="RepeatModeButton" DataContext="{Binding ViewModels.RepeatModeButtonViewModel}"
+                Width="{Binding Width}"
+                Height="{Binding Height}"
+                Visibility="{Binding IsVisible, Converter={x:Static converters:Converters.BoolToVisibility}}"
+                Canvas.Left="{Binding XPosition}" Canvas.Top="{Binding YPosition}"
+                Style="{StaticResource ToolbarRepeatModeButtonStyle}"
+                Command="{Binding CycleRepeatModeCommand}"/>
         <Slider x:Name="ProgressBar" DataContext="{Binding ViewModels.ProgressBarVM}"
                 Width="{Binding Width}" Height="{Binding Height}"
                 Visibility="{Binding IsVisible, Converter={x:Static converters:Converters.BoolToVisibility}}"

--- a/src/AudioBand/Views/Settings/ButtonBaseTemplate.xaml
+++ b/src/AudioBand/Views/Settings/ButtonBaseTemplate.xaml
@@ -1,0 +1,43 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:AudioBand.Views.Settings"
+                    xmlns:resources="clr-namespace:AudioBand.Resources"
+                    xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                    xmlns:behaviors="clr-namespace:AudioBand.Behaviors"
+                    xmlns:models="clr-namespace:AudioBand.Models"
+                    xmlns:viewModels="clr-namespace:AudioBand.ViewModels"
+                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    mc:Ignorable="d">
+    <DataTemplate x:Key="ButtonBaseTemplate">
+        <DataTemplate.Resources>
+            <ResourceDictionary>
+                <ResourceDictionary.MergedDictionaries>
+                    <resources:SharedDictionary Source="../../Resources/SettingsWindowStyle.xaml"/>
+                    <resources:SharedDictionary Source="../../Resources/Strings.xaml"/>
+                </ResourceDictionary.MergedDictionaries>
+            </ResourceDictionary>
+        </DataTemplate.Resources>
+        <StackPanel Style="{StaticResource SettingsStackPanel}" KeyboardNavigation.IsTabStop="False">
+            <TextBlock Text="{StaticResource DisplaySectionText}" Style="{StaticResource TitleTextBlock}"/>
+            <TextBlock Text="{StaticResource VisibilityLabelText}" Style="{StaticResource DescriptionTextBlock}"/>
+            <mah:ToggleSwitch OnLabel="{StaticResource StatusVisible}" OffLabel="{StaticResource StatusHidden}"
+                            IsChecked="{Binding IsVisible, Mode=TwoWay}"/>
+            <UniformGrid Rows="4" Columns="2" Style="{StaticResource ArrangementGridStyle}">
+                <TextBlock Text="{StaticResource WidthLabelText}" Style="{StaticResource DescriptionTextBlock}"/>
+                <TextBlock Text="{StaticResource HeightLabelText}" Style="{StaticResource DescriptionTextBlock}"/>
+                <mah:NumericUpDown behaviors:NumericInput.Type="Size" Value="{Binding Width, Mode=TwoWay}"/>
+                <mah:NumericUpDown behaviors:NumericInput.Type="Size" Value="{Binding Height, Mode=TwoWay}"/>
+                <TextBlock Text="{StaticResource XPositionLabelText}" Style="{StaticResource DescriptionTextBlock}"/>
+                <TextBlock Text="{StaticResource YPositionLabelText}" Style="{StaticResource DescriptionTextBlock}"/>
+                <mah:NumericUpDown behaviors:NumericInput.Type="Position" Value="{Binding XPosition, Mode=TwoWay}"/>
+                <mah:NumericUpDown behaviors:NumericInput.Type="Position" Value="{Binding YPosition, Mode=TwoWay}"/>
+            </UniformGrid>
+
+            <TextBlock Margin="{StaticResource SectionMargin}" Text="{StaticResource BackgroundColorSectionText}" Style="{StaticResource TitleTextBlock}"/>
+            <local:ColorPicker Color="{Binding BackgroundColor}" DialogService="{Binding DialogService}" Title="{StaticResource DefaultColorLabelText}"/>
+            <local:ColorPicker Color="{Binding HoveredBackgroundColor}" DialogService="{Binding DialogService}" Title="{StaticResource ProgressBarHoverColorDescription}"/>
+            <local:ColorPicker Color="{Binding ClickedBackgroundColor}" DialogService="{Binding DialogService}" Title="{StaticResource ClickedColorLabelText}"/>
+        </StackPanel>
+    </DataTemplate>
+</ResourceDictionary>

--- a/src/AudioBand/Views/Settings/ButtonContentTemplate.xaml
+++ b/src/AudioBand/Views/Settings/ButtonContentTemplate.xaml
@@ -1,0 +1,60 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:AudioBand.Views.Settings"
+                    xmlns:viewModels="clr-namespace:AudioBand.ViewModels"
+                    xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                    xmlns:behaviors="clr-namespace:AudioBand.Behaviors"
+                    xmlns:models="clr-namespace:AudioBand.Models"
+                    xmlns:resources="clr-namespace:AudioBand.Resources">
+    <DataTemplate x:Key="ButtonContentTemplate" DataType="{x:Type viewModels:ButtonContentViewModel}">
+        <DataTemplate.Resources>
+            <ResourceDictionary>
+                <ResourceDictionary.MergedDictionaries>
+                    <resources:SharedDictionary Source="../../Resources/SettingsWindowStyle.xaml"/>
+                    <resources:SharedDictionary Source="../../Resources/Strings.xaml"/>
+                </ResourceDictionary.MergedDictionaries>
+            </ResourceDictionary>
+        </DataTemplate.Resources>
+        <StackPanel Style="{StaticResource SettingsStackPanel}" KeyboardNavigation.IsTabStop="False">
+            <TextBlock Text="{StaticResource ButtonContentTypeDescription}" Style="{StaticResource DescriptionTextBlock}"/>
+            <ComboBox ItemsSource="{Binding ButtonContentTypes}" ItemTemplate="{StaticResource EnumDescriptorItemTemplate}"
+                      SelectedValue="{Binding ContentType}" SelectedValuePath="Value"/>
+            <ItemsControl IsTabStop="False">
+                <ItemsControl.Style>
+                    <Style TargetType="{x:Type ItemsControl}">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ContentType}" Value="{x:Static models:ButtonContentType.Image}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ItemsControl.Style>
+                <local:ImagePicker ImagePath="{Binding ImagePath, Mode=TwoWay}" DialogService="{Binding DialogService}" Title="{StaticResource ButtonImageLabelText}"/>
+                <local:ImagePicker ImagePath="{Binding HoveredImagePath, Mode=TwoWay}" DialogService="{Binding DialogService}" Title="{StaticResource ButtonHoveredImageLabelText}"/>
+                <local:ImagePicker ImagePath="{Binding ClickedImagePath, Mode=TwoWay}" DialogService="{Binding DialogService}" Title="{StaticResource ButtonClickedImageLabelText}"/>
+            </ItemsControl>
+            <ItemsControl IsTabStop="False">
+                <ItemsControl.Style>
+                    <Style TargetType="{x:Type ItemsControl}">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ContentType}" Value="{x:Static models:ButtonContentType.Text}">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ItemsControl.Style>
+                <TextBlock Text="{StaticResource ButtonFontFamilyDescription}" Style="{StaticResource DescriptionTextBlock}"/>
+                <ComboBox ItemsSource="{Binding Source={x:Static Fonts.SystemFontFamilies}}" IsEditable="True"
+                          SelectedValue="{Binding FontFamily}" SelectedValuePath="Source"
+                          ItemTemplate="{StaticResource FontFamilyComboBoxItemDataTemplate}" Width="400"/>
+                <TextBlock Text="{StaticResource ButtonTextDescription}" Style="{StaticResource DescriptionTextBlock}"/>
+                <TextBox Text="{Binding Text}" FontFamily="{Binding FontFamily}" Width="100"/>
+                <local:ColorPicker Color="{Binding TextColor}" DialogService="{Binding DialogService}" Title="{StaticResource ButtonTextColorDescription}"/>
+                <local:ColorPicker Color="{Binding HoveredTextColor}" DialogService="{Binding DialogService}" Title="{StaticResource ButtonTextHoverColorDescription}"/>
+                <local:ColorPicker Color="{Binding ClickedTextColor}" DialogService="{Binding DialogService}" Title="{StaticResource ButtonTextClickedColorDescription}"/>
+            </ItemsControl>
+        </StackPanel>
+    </DataTemplate>
+</ResourceDictionary>

--- a/src/AudioBand/Views/Settings/RepeatModeButtonSettingsView.xaml
+++ b/src/AudioBand/Views/Settings/RepeatModeButtonSettingsView.xaml
@@ -1,0 +1,35 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:AudioBand.Views.Settings"
+                    xmlns:viewmodels="clr-namespace:AudioBand.ViewModels"
+                    xmlns:resources="clr-namespace:AudioBand.Resources">
+    <DataTemplate DataType="{x:Type viewmodels:RepeatModeButtonViewModel}">
+        <DataTemplate.Resources>
+            <ResourceDictionary>
+                <ResourceDictionary.MergedDictionaries>
+                    <resources:SharedDictionary Source="../../Resources/SettingsWindowStyle.xaml"/>
+                    <resources:SharedDictionary Source="../../Resources/Strings.xaml"/>
+                    <resources:SharedDictionary Source="ButtonBaseTemplate.xaml"/>
+                    <resources:SharedDictionary Source="ButtonContentTemplate.xaml"/>
+                </ResourceDictionary.MergedDictionaries>
+            </ResourceDictionary>
+        </DataTemplate.Resources>
+        <StackPanel Style="{StaticResource SettingsStackPanel}">
+            <ContentPresenter Content="{Binding}" ContentTemplate="{StaticResource ButtonBaseTemplate}" Focusable="False"/>
+
+            <TextBlock Margin="{StaticResource SectionMargin}" Text="{StaticResource RepeatModeButtonOffContentSectionText}" Style="{StaticResource TitleTextBlock}"/>
+            <ContentPresenter Content="{Binding RepeatOffContent}" ContentTemplate="{StaticResource ButtonContentTemplate}" Focusable="False"/>
+
+            <TextBlock Margin="{StaticResource SectionMargin}" Text="{StaticResource RepeatModeButtonContextContentSectionText}" Style="{StaticResource TitleTextBlock}"/>
+            <ContentPresenter Content="{Binding RepeatContextContent}" ContentTemplate="{StaticResource ButtonContentTemplate}" Focusable="False"/>
+
+            <TextBlock Margin="{StaticResource SectionMargin}" Text="{StaticResource RepeatModeButtonTrackContentSectionText}" Style="{StaticResource TitleTextBlock}"/>
+            <ContentPresenter Content="{Binding RepeatTrackContent}" ContentTemplate="{StaticResource ButtonContentTemplate}" Focusable="False"/>
+
+            <TextBlock Margin="{StaticResource SectionMargin}" Text="{StaticResource OtherSectionText}" Style="{StaticResource TitleTextBlock}"/>
+            <Button HorizontalAlignment="Left"
+                    Content="{StaticResource ResetButtonText}"
+                    Command="{Binding ResetCommand}"/>
+        </StackPanel>
+    </DataTemplate>
+</ResourceDictionary>

--- a/src/AudioBand/Views/Settings/SettingsWindow.xaml
+++ b/src/AudioBand/Views/Settings/SettingsWindow.xaml
@@ -96,6 +96,13 @@
                         </StackPanel>
                     </RadioButton>
                     <RadioButton Style="{StaticResource NavigationPaneRadioButton}" GroupName="nav"
+                                 Command="{Binding SelectViewModelCommand}" CommandParameter="{Binding ViewModels.RepeatModeButtonViewModel}">
+                        <StackPanel Orientation="Horizontal">
+                            <Image Style="{StaticResource NavigationPaneIcon}" Source="{StaticResource RepeatModeIcon}"/>
+                            <TextBlock Text="{StaticResource RepeatModeButtonTab}"/>
+                        </StackPanel>
+                    </RadioButton>
+                    <RadioButton Style="{StaticResource NavigationPaneRadioButton}" GroupName="nav"
                                  Command="{Binding SelectViewModelCommand}" CommandParameter="{Binding ViewModels.ProgressBarVM}">
                         <StackPanel Orientation="Horizontal">
                             <Image Style="{StaticResource NavigationPaneIcon}" Source="{StaticResource Progress}"/>
@@ -303,6 +310,9 @@
                             <DataTrigger Binding="{Binding SelectedViewModel, Converter={x:Static converters:Converters.ObjectToType}}" Value="{x:Type viewmodels:ProgressBarVM}">
                                 <Setter Property="Text" Value="{StaticResource ProgressBarTab}"/>
                             </DataTrigger>
+                            <DataTrigger Binding="{Binding SelectedViewModel, Converter={x:Static converters:Converters.ObjectToType}}" Value="{x:Type viewmodels:RepeatModeButtonViewModel}">
+                                <Setter Property="Text" Value="{StaticResource RepeatModeButtonTab}"/>
+                            </DataTrigger>
                         </Style.Triggers>
                     </Style>
                 </TextBlock.Style>
@@ -312,14 +322,15 @@
                 <ContentControl.Resources>
                     <ResourceDictionary>
                         <ResourceDictionary.MergedDictionaries>
-                            <ResourceDictionary Source="AlbumArtSettingsView.xaml"/>
-                            <ResourceDictionary Source="AlbumPopupSettingsView.xaml"/>
-                            <ResourceDictionary Source="AudioSourceSettingsView.xaml"/>
-                            <ResourceDictionary Source="CustomLabelSettingsView.xaml"/>
-                            <ResourceDictionary Source="GeneralSettingsView.xaml"/>
-                            <ResourceDictionary Source="PlaybackButtonSettingsView.xaml"/>
-                            <ResourceDictionary Source="PlayPauseButtonSettingsView.xaml"/>
-                            <ResourceDictionary Source="ProgressBarSettingsView.xaml"/>
+                            <resources:SharedDictionary Source="AlbumArtSettingsView.xaml"/>
+                            <resources:SharedDictionary Source="AlbumPopupSettingsView.xaml"/>
+                            <resources:SharedDictionary Source="AudioSourceSettingsView.xaml"/>
+                            <resources:SharedDictionary Source="CustomLabelSettingsView.xaml"/>
+                            <resources:SharedDictionary Source="GeneralSettingsView.xaml"/>
+                            <resources:SharedDictionary Source="PlaybackButtonSettingsView.xaml"/>
+                            <resources:SharedDictionary Source="PlayPauseButtonSettingsView.xaml"/>
+                            <resources:SharedDictionary Source="ProgressBarSettingsView.xaml"/>
+                            <resources:SharedDictionary Source="RepeatModeButtonSettingsView.xaml"/>
                         </ResourceDictionary.MergedDictionaries>
                     </ResourceDictionary>
                 </ContentControl.Resources>


### PR DESCRIPTION
- Split the button models into a `ButtonContent` model and a base `ButtonBase` mode so its easier to template and compose new buttons. The repeat mode button uses the new models. Will refactor the other buttons at a later date.
- Add a IAsyncCommand between AsyncRelayCommand and ICommand so that its easier to test the async execute