### PR TITLE
Fix audio source settings changed event not causing a save

### DIFF
--- a/src/AudioBand.Test/ViewModels/AudioSourceSettingsCollectionTests.cs
+++ b/src/AudioBand.Test/ViewModels/AudioSourceSettingsCollectionTests.cs
@@ -4,6 +4,7 @@ using AudioBand.ViewModels;
 using Moq;
 using System.Collections.Generic;
 using AudioBand.Messages;
+using AudioBand.Settings;
 using Xunit;
 
 namespace AudioBand.Test
@@ -12,11 +13,13 @@ namespace AudioBand.Test
     {
         private Mock<IInternalAudioSource> _audioSourceMock;
         private Mock<IMessageBus> _messageBus;
+        private Mock<IAppSettings> _appSettings;
 
         public AudioSourceSettingsCollectionTests()
         {
             _audioSourceMock = new Mock<IInternalAudioSource>();
             _messageBus = new Mock<IMessageBus>();
+            _appSettings = new Mock<IAppSettings>();
         }
 
         [Fact]
@@ -33,7 +36,7 @@ namespace AudioBand.Test
             };
             var settings = new AudioSourceSettings { AudioSourceName = name, Settings = keyVals };
 
-            var vm = new AudioSourceSettingsCollectionViewModel(_audioSourceMock.Object, settings, _messageBus.Object);
+            var vm = new AudioSourceSettingsCollectionViewModel(_audioSourceMock.Object, settings, _messageBus.Object, _appSettings.Object);
 
             Assert.Empty(vm.SettingsList);
             Assert.Equal(name, vm.AudioSourceName);
@@ -65,7 +68,7 @@ namespace AudioBand.Test
             };
 
             var settings = new AudioSourceSettings { Settings = settingModels };
-            var vm = new AudioSourceSettingsCollectionViewModel(_audioSourceMock.Object, settings, _messageBus.Object);
+            var vm = new AudioSourceSettingsCollectionViewModel(_audioSourceMock.Object, settings, _messageBus.Object, _appSettings.Object);
 
             Assert.Equal(settingModels.Count, vm.SettingsList.Count);
             Assert.Equal(settingModels[0].Name, vm.SettingsList[0].Name);
@@ -88,12 +91,12 @@ namespace AudioBand.Test
             object newSettingValue = 1;
             _audioSourceMock.SetupGet(s => s[It.Is<string>(x => x == setting)]).Returns(newSettingValue);
 
-            var vm = new AudioSourceSettingsCollectionViewModel(_audioSourceMock.Object, settings, _messageBus.Object);
+            var vm = new AudioSourceSettingsCollectionViewModel(_audioSourceMock.Object, settings, _messageBus.Object, _appSettings.Object);
 
             _audioSourceMock.Raise(s => s.SettingChanged += null, new SettingChangedEventArgs(setting));
 
-            vm.EndEdit();
             Assert.Equal(newSettingValue, settingModel.Value);
+            _appSettings.Verify(m => m.Save(), Times.Once);
         }
        
         [Fact]
@@ -121,7 +124,7 @@ namespace AudioBand.Test
             _audioSourceMock.InSequence(s).SetupSet(source => source[It.Is<string>(x => x == setting1.Name)] = null);
             _audioSourceMock.InSequence(s).SetupSet(source => source[It.Is<string>(x => x == setting2.Name)] = null);
 
-            var vm = new AudioSourceSettingsCollectionViewModel(_audioSourceMock.Object, settings, _messageBus.Object);
+            var vm = new AudioSourceSettingsCollectionViewModel(_audioSourceMock.Object, settings, _messageBus.Object, _appSettings.Object);
 
             _audioSourceMock.VerifySet(source => source[setting3.Name] = null);
             _audioSourceMock.VerifySet(source => source[setting1.Name] = null);

--- a/src/AudioBand/ViewModels/AudioSourceSettingKeyValue.cs
+++ b/src/AudioBand/ViewModels/AudioSourceSettingKeyValue.cs
@@ -96,6 +96,14 @@ namespace AudioBand.ViewModels
             }
         }
 
+        /// <summary>
+        /// When the audio sources updates the setting itself instead of from audioband. Sync the changes back to the model.
+        /// </summary>
+        public void SyncToModel()
+        {
+            MapSelf(_model, _originalSource);
+        }
+
         /// <inheritdoc />
         protected override void OnBeginEdit()
         {
@@ -124,7 +132,7 @@ namespace AudioBand.ViewModels
                 return;
             }
 
-            MapSelf(_model, _originalSource);
+            SyncToModel();
             PropagateSettingToAudioSource();
         }
     }

--- a/src/AudioBand/ViewModels/AudioSourceSettingsViewModel.cs
+++ b/src/AudioBand/ViewModels/AudioSourceSettingsViewModel.cs
@@ -48,14 +48,14 @@ namespace AudioBand.ViewModels
             var matchingSetting = _appSettings.AudioSourceSettings.FirstOrDefault(s => s.AudioSourceName == audioSource.Name);
             if (matchingSetting != null)
             {
-                var viewModel = new AudioSourceSettingsCollectionViewModel(audioSource, matchingSetting, _messageBus);
+                var viewModel = new AudioSourceSettingsCollectionViewModel(audioSource, matchingSetting, _messageBus, _appSettings);
                 AudioSourcesSettings.Add(viewModel);
             }
             else
             {
                 var newSettingsModel = new AudioSourceSettings { AudioSourceName = audioSource.Name };
                 _appSettings.AudioSourceSettings.Add(newSettingsModel);
-                var newViewModel = new AudioSourceSettingsCollectionViewModel(audioSource, newSettingsModel, _messageBus);
+                var newViewModel = new AudioSourceSettingsCollectionViewModel(audioSource, newSettingsModel, _messageBus, _appSettings);
                 AudioSourcesSettings.Add(newViewModel);
             }
 


### PR DESCRIPTION
# Summary
An audio source can update a setting internally (i.e. for saving internal settings), since settings are only serialized normally through the settings window, this can cause a situation where the audio source settings aren't saved.

Example of this issue: #207 