### PR TITLE
Fix migration errors from older settings

### DIFF
--- a/src/AudioBand/AudioBand.csproj
+++ b/src/AudioBand/AudioBand.csproj
@@ -107,6 +107,8 @@
     <Compile Include="Behaviors\SliderClickAndDrag.cs" />
     <Compile Include="Behaviors\TrackOffsetFix.cs" />
     <Compile Include="Commands\AsyncRelayCommand.cs" />
+    <Compile Include="Settings\Migrations\IdentityMigrator.cs" />
+    <Compile Include="Settings\TomlHelper.cs" />
     <Compile Include="ValueConverters\ValueConverterHelper.cs" />
     <Compile Include="ViewModels\TrackStateAttribute.cs" />
     <Compile Include="Commands\AsyncRelayCommand{T}.cs" />

--- a/src/AudioBand/Settings/Migrations/IdentityMigrator.cs
+++ b/src/AudioBand/Settings/Migrations/IdentityMigrator.cs
@@ -1,0 +1,18 @@
+﻿namespace AudioBand.Settings.Migrations
+{
+    /// <summary>
+    /// Performs no migration.
+    /// </summary>
+    internal class IdentityMigrator : ISettingsMigrator
+    {
+        /// <summary>
+        /// Migrate settings to new version.
+        /// </summary>
+        /// <param name="oldSetting">Old settings to migrate.</param>
+        /// <returns>The new settings.</returns>
+        public object MigrateSetting(object oldSetting)
+        {
+            return oldSetting;
+        }
+    }
+}

--- a/src/AudioBand/Settings/TomlHelper.cs
+++ b/src/AudioBand/Settings/TomlHelper.cs
@@ -1,0 +1,27 @@
+﻿using System.Windows.Media;
+using AudioBand.Models;
+using Nett;
+
+namespace AudioBand.Settings
+{
+    /// <summary>
+    /// Helper for TOML serialization and deserialization.
+    /// </summary>
+    internal static class TomlHelper
+    {
+        /// <summary>
+        /// Gets the default settings for TOML de/serialization.
+        /// </summary>
+        public static TomlSettings DefaultSettings { get; } = TomlSettings.Create(cfg =>
+        {
+            cfg.ConfigureType<Color>(type => type.WithConversionFor<TomlString>(convert => convert
+                .ToToml(SerializationConversions.ColorToString)
+                .FromToml(tomlString => SerializationConversions.StringToColor(tomlString.Value))));
+            cfg.ConfigureType<CustomLabel.TextAlignment>(type => type.WithConversionFor<TomlString>(convert => convert
+                .ToToml(SerializationConversions.EnumToString)
+                .FromToml(str => SerializationConversions.StringToEnum<CustomLabel.TextAlignment>(str.Value))));
+            cfg.ConfigureType<double>(type => type.WithConversionFor<TomlInt>(c => c
+                .FromToml(tml => tml.Value)));
+        });
+    }
+}

--- a/src/AudioBandRules.ruleset
+++ b/src/AudioBandRules.ruleset
@@ -19,5 +19,6 @@
     <Rule Id="SA1641" Action="None" />
     <Rule Id="SX1101" Action="Warning" />
     <Rule Id="SX1309" Action="Warning" />
+    <Rule Id="SA0001" Action="None" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
## Summary
Fix migration errors when migrating more than one migration needs to be applied.

## Checklist
- [x] Tests passed
- [x] Changes validated (manually or automated)
- [x] Closes / Fixes #208 (if applicable)

## Additional details / comments
Never had proper tests for this apparently. If more than one migration was required, then it was unable to find to correct set to apply. For example `v1 -> v3`, it would try to find (and fail) a direct migration plan for it instead of doing `v1 -> v2 -> v3`.

Also added more sanity checks for potential migration errors.

## Manual test steps (if applicable)
Also did manual tests, since the infrastructure for integration test isn't set up yet.
1. Have old 0.1 `audioband.settings` file in `%appdata%/AudioBand` folder.
2. Start audioband.
3. Verify no crash, and settings are migrated.