### PR TITLE
Fix custom labels not saving settings properly

### DIFF
--- a/src/AudioBand.Test/ViewModels/CustomLabelViewModelTests.cs
+++ b/src/AudioBand.Test/ViewModels/CustomLabelViewModelTests.cs
@@ -73,5 +73,34 @@ namespace AudioBand.Test
 
             Assert.All(vm.TextSegments, segment => Assert.Equal(Colors.Blue, segment.Color));
         }
+
+        [Fact]
+        void CustomLabel_CancelEdit_ModelHasNoChanges()
+        {
+            var formatString = "test";
+            var model = new CustomLabel {FormatString = formatString};
+            var vm = new CustomLabelViewModel(model, _dialogMock.Object, _sessionMock.Object, _messageBusMock.Object);
+
+            vm.FormatString = "new";
+            vm.CancelEdit();
+
+            Assert.Equal(formatString, vm.FormatString);
+            Assert.Equal(formatString, model.FormatString);
+        }
+
+        [Fact]
+        void CustomLabel_SaveEdit_ModelHasNewChanges()
+        {
+            var formatString = "test";
+            var newFormatstring = "format";
+            var model = new CustomLabel { FormatString = formatString };
+            var vm = new CustomLabelViewModel(model, _dialogMock.Object, _sessionMock.Object, _messageBusMock.Object);
+
+            vm.FormatString = newFormatstring;
+            vm.EndEdit();
+
+            Assert.Equal(newFormatstring, vm.FormatString);
+            Assert.Equal(newFormatstring, model.FormatString);
+        }
     }
 }

--- a/src/AudioBand.Test/ViewModels/CustomLabelsViewModelTests.cs
+++ b/src/AudioBand.Test/ViewModels/CustomLabelsViewModelTests.cs
@@ -137,5 +137,29 @@ namespace AudioBand.Test
             _appSettingsMock.Raise(m => m.ProfileChanged += null, null, EventArgs.Empty);
             Assert.True(vm.CustomLabels[0].IsPlaying);
         }
+
+        [Fact]
+        public void RemoveLabel_PublishEdit()
+        {
+            _appSettingsMock.SetupGet(x => x.CustomLabels).Returns(new List<CustomLabel> { new CustomLabel() });
+            _dialogMock.Setup(o => o.ShowConfirmationDialog(It.IsAny<ConfirmationDialogType>(), It.IsAny<object>())).Returns(true);
+            _viewModel = new CustomLabelsViewModel(_appSettingsMock.Object, _dialogMock.Object, _sessionMock.Object, _messageBus.Object);
+            var label = _viewModel.CustomLabels[0];
+            _viewModel.RemoveLabelCommand.Execute(label);
+
+            Assert.True(_viewModel.IsEditing);
+            _messageBus.Verify(m => m.Publish(It.IsAny<EditStartMessage>(), It.IsAny<string>()));
+        }
+
+        [Fact]
+        public void AddLabel_PublishEdit()
+        {
+            _appSettingsMock.SetupGet(x => x.CustomLabels).Returns(new List<CustomLabel> { new CustomLabel() });
+            _viewModel = new CustomLabelsViewModel(_appSettingsMock.Object, _dialogMock.Object, _sessionMock.Object, _messageBus.Object);
+            _viewModel.AddLabelCommand.Execute(null);
+
+            Assert.True(_viewModel.IsEditing);
+            _messageBus.Verify(m => m.Publish(It.IsAny<EditStartMessage>(), It.IsAny<string>()));
+        }
     }
 }

--- a/src/AudioBand/ViewModels/CustomLabelViewModel.cs
+++ b/src/AudioBand/ViewModels/CustomLabelViewModel.cs
@@ -17,6 +17,7 @@ namespace AudioBand.ViewModels
     /// </summary>
     public class CustomLabelViewModel : LayoutViewModelBase<CustomLabel>
     {
+        private readonly CustomLabel _source;
         private readonly IAudioSession _audioSession;
         private bool _isPlaying;
         private IEnumerable<TextSegment> _textSegments;
@@ -31,6 +32,7 @@ namespace AudioBand.ViewModels
         public CustomLabelViewModel(CustomLabel source, IDialogService dialogService, IAudioSession audioSession, IMessageBus messageBus)
             : base(messageBus, source)
         {
+            _source = source;
             _audioSession = audioSession;
             _audioSession.PropertyChanged += AudioSessionOnPropertyChanged;
 
@@ -241,6 +243,13 @@ namespace AudioBand.ViewModels
             base.OnReset();
             RefreshSegmentColors();
             ReParseSegments();
+        }
+
+        /// <inheritdoc />
+        protected override void OnEndEdit()
+        {
+            base.OnEndEdit();
+            MapSelf(Model, _source);
         }
 
         private void AudioSessionOnPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/AudioBand/ViewModels/CustomLabelsViewModel.cs
+++ b/src/AudioBand/ViewModels/CustomLabelsViewModel.cs
@@ -61,6 +61,8 @@ namespace AudioBand.ViewModels
         /// <inheritdoc/>
         protected override void OnBeginEdit()
         {
+            base.OnBeginEdit();
+
             _added.Clear();
             _removed.Clear();
         }
@@ -68,6 +70,8 @@ namespace AudioBand.ViewModels
         /// <inheritdoc/>
         protected override void OnCancelEdit()
         {
+            base.OnCancelEdit();
+
             foreach (var label in _added)
             {
                 CustomLabels.Remove(label);
@@ -85,6 +89,8 @@ namespace AudioBand.ViewModels
         /// <inheritdoc/>
         protected override void OnEndEdit()
         {
+            base.OnEndEdit();
+
             _added.Clear();
             _removed.Clear();
 
@@ -108,12 +114,12 @@ namespace AudioBand.ViewModels
 
         private void RemoveLabelCommandOnExecute(CustomLabelViewModel labelViewModel)
         {
-            BeginEdit();
-
             if (!_dialogService.ShowConfirmationDialog(ConfirmationDialogType.DeleteLabel, labelViewModel.Name))
             {
                 return;
             }
+
+            BeginEdit();
 
             CustomLabels.Remove(labelViewModel);
 


### PR DESCRIPTION
## Summary
Text labels were not writing the changes back to application settings.

## Checklist
- [x] Tests passed
- [x] Changes validated (manually or automated)
- [x] Closes / Fixes #206 (if applicable)

## Additional details / comments
`OnEndEdit` was not being overridden properly to write the values back to the source. Additionally fixed removing labels not publishing an edit start message.

## Manual test steps (if applicable)
1. Edit custom label position.
2. Press apply.
3. Reset explorer
4. Observe that the values have been saved properly.