### PR TITLE
Update WM_DPICHANGED message handling

### DIFF
--- a/src/AudioBand/NativeMethods.cs
+++ b/src/AudioBand/NativeMethods.cs
@@ -195,6 +195,23 @@ namespace AudioBand
             public uint GradientColor;
             public int AnimationId;
         }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RECT
+        {
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
+
+            public RECT(int left, int top, int right, int bottom)
+            {
+                Left = left;
+                Top = top;
+                Right = right;
+                Bottom = bottom;
+            }
+        }
     }
 #pragma warning restore
 }


### PR DESCRIPTION
## Summary
Update handler to use the `lparam` which contains the suggested rect.

## Checklist
- [x] Tests passed
- [x] Changes validated (manually or automated)
- [x] Closes / Fixes #202 (if applicable)

## Additional details / comments
According the docs, you are supposed to make use of the suggested rect passed in.

## Manual test steps (if applicable)
1. Setup multiple monitors with different DPIs
2. Move settings window between them
3. Observe that the window doesn't jump around and the mouse is still in the same relative position