### PR TITLE
Fix Spotify proxy authentication

### DIFF
--- a/src/AudioBand/UI/Behaviors/PasswordBehaviour.cs
+++ b/src/AudioBand/UI/Behaviors/PasswordBehaviour.cs
@@ -5,7 +5,7 @@ using System.Windows.Interactivity;
 namespace AudioBand.UI
 {
     /// <summary>
-    /// Behaviour for a password box to allow binding. From http://www.wpftutorial.net/PasswordBox.html
+    /// Behaviour for a password box to allow binding. From http://www.wpftutorial.net/PasswordBox.html.
     /// </summary>
     internal class PasswordBehaviour : Behavior<PasswordBox>
     {

--- a/src/AudioBand/UI/Behaviors/PasswordBehaviour.cs
+++ b/src/AudioBand/UI/Behaviors/PasswordBehaviour.cs
@@ -5,14 +5,21 @@ using System.Windows.Interactivity;
 namespace AudioBand.UI
 {
     /// <summary>
-    /// Behaviour for a password box.
+    /// Behaviour for a password box to allow binding. From http://www.wpftutorial.net/PasswordBox.html
     /// </summary>
     internal class PasswordBehaviour : Behavior<PasswordBox>
     {
         /// <summary>
         /// Dependency property for the password.
         /// </summary>
-        public static readonly DependencyProperty PasswordProperty = DependencyProperty.Register(nameof(Password), typeof(string), typeof(PasswordBehaviour));
+        public static readonly DependencyProperty PasswordProperty
+            = DependencyProperty.Register(nameof(Password), typeof(string), typeof(PasswordBehaviour), new PropertyMetadata(string.Empty, OnPasswordPropertyChanged));
+
+        /// <summary>
+        /// Dependency property for <see cref="IsUpdating"/>.
+        /// </summary>
+        public static readonly DependencyProperty IsUpdatingProperty
+            = DependencyProperty.RegisterAttached(nameof(IsUpdating), typeof(bool), typeof(PasswordBehaviour), new PropertyMetadata(default(bool)));
 
         /// <summary>
         /// Gets or sets the current password.
@@ -23,11 +30,21 @@ namespace AudioBand.UI
             set => SetValue(PasswordProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the password is being updated.
+        /// </summary>
+        public bool IsUpdating
+        {
+            get => (bool)GetValue(IsUpdatingProperty);
+            set => SetValue(IsUpdatingProperty, value);
+        }
+
         /// <inheritdoc/>
         protected override void OnAttached()
         {
             base.OnAttached();
 
+            AssociatedObject.Password = Password;
             AssociatedObject.PasswordChanged += PasswordChanged;
         }
 
@@ -42,9 +59,34 @@ namespace AudioBand.UI
             }
         }
 
+        private static void OnPasswordPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        {
+            var behaviour = (PasswordBehaviour)sender;
+            behaviour.PasswordPropertyChanged((string)e.NewValue);
+        }
+
         private void PasswordChanged(object sender, RoutedEventArgs routedEventArgs)
         {
+            IsUpdating = true;
             Password = AssociatedObject.Password;
+            IsUpdating = false;
+        }
+
+        private void PasswordPropertyChanged(string value)
+        {
+            if (AssociatedObject == null)
+            {
+                return;
+            }
+
+            AssociatedObject.PasswordChanged -= PasswordChanged;
+
+            if (!IsUpdating)
+            {
+                AssociatedObject.Password = value;
+            }
+
+            AssociatedObject.PasswordChanged += PasswordChanged;
         }
     }
 }

--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -270,6 +270,8 @@ namespace SpotifyAudioSource
         /// <inheritdoc />
         public Task PlayTrackAsync()
         {
+            // Play/pause/next/back controls use the desktop rather than the api
+            // because it is quicker and player controls require spotify premium.
             _spotifyControls.Play();
             return Task.CompletedTask;
         }
@@ -582,6 +584,7 @@ namespace SpotifyAudioSource
 
         private async void CheckSpotifyTimerOnElapsed(object sender, ElapsedEventArgs elapsedEventArgs)
         {
+            // Spotify api does not provide a way to get realtime player status updates, so we have to resort to polling.
             try
             {
                 if (!_isActive || string.IsNullOrEmpty(_spotifyApi.AccessToken))

--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -6,7 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Timers;
 using AudioBand.AudioSource;
-using SpotifyAPI;
 using SpotifyAPI.Web;
 using SpotifyAPI.Web.Auth;
 using SpotifyAPI.Web.Enums;
@@ -364,7 +363,6 @@ namespace SpotifyAudioSource
             _auth?.Stop();
             _auth = new AuthorizationCodeAuth(ClientId, ClientSecret, url, url, Scope.UserModifyPlaybackState | Scope.UserReadPlaybackState | Scope.UserReadCurrentlyPlaying);
 
-            Logger.Debug($"Using proxy {UseProxy}, {_proxyConfig.Host} {_proxyConfig.Password}, {_proxyConfig.Username}, {_proxyConfig.GetUri()}");
             if (UseProxy)
             {
                 _auth.ProxyConfig = _proxyConfig;

--- a/src/SpotifyAudioSource/SpotifyAudioSource.csproj
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.csproj
@@ -107,10 +107,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SpotifyAPI.Web">
-      <Version>4.1.1</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="SpotifyAPI.Web.Auth">
-      <Version>4.1.0</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>

--- a/src/SpotifyAudioSource/SpotifyAudioSource.csproj
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.csproj
@@ -107,10 +107,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SpotifyAPI.Web">
-      <Version>4.2.0</Version>
+      <Version>4.2.1</Version>
     </PackageReference>
     <PackageReference Include="SpotifyAPI.Web.Auth">
-      <Version>4.2.0</Version>
+      <Version>4.2.1</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>


### PR DESCRIPTION
## Summary
Fixes authenticated proxy settings not working for Spotfiy.

## Checklist
- [x] Tests passed
- [x] Changes validated (manually or automated)
- [x] Closes / Fixes #201 (if applicable)

## Additional details / comments
Authorization was missing proxy settings, so the proxy would work if it was already authorized and the refresh token was saved. But for a fresh setup with proxy credentials, it wouldn't work.

Passing proxy options to the authorization step required an update to the spotify library.

## Manual test steps (if applicable)
Tested proxy options with and without authentication by using fiddler.

||With new spotify client id / secret|Reusing refresh token|
|---|---|---|
|With proxy creds|x|x|
|With no creds|x|x|