### PR TITLE
Spotify: update error handling for player commands

### DIFF
--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -249,22 +249,22 @@ namespace SpotifyAudioSource
 
         public async Task SetVolumeAsync(float newVolume)
         {
-            await _spotifyApi.SetVolumeAsync((int)(newVolume * 100));
+            await LogActionIfFailed(() => _spotifyApi.SetVolumeAsync((int)(newVolume * 100)));
         }
 
         public async Task SetPlaybackProgressAsync(TimeSpan newProgress)
         {
-            await _spotifyApi.SeekPlaybackAsync((int)newProgress.TotalMilliseconds);
+            await LogActionIfFailed(() => _spotifyApi.SeekPlaybackAsync((int)newProgress.TotalMilliseconds));
         }
 
         public async Task SetShuffleAsync(bool shuffleOn)
         {
-            await _spotifyApi.SetShuffleAsync(shuffleOn);
+            await LogActionIfFailed(() => _spotifyApi.SetShuffleAsync(shuffleOn));
         }
 
         public async Task SetRepeatModeAsync(RepeatMode newRepeatMode)
         {
-            await _spotifyApi.SetRepeatModeAsync(ToRepeatState(newRepeatMode));
+            await LogActionIfFailed(() => _spotifyApi.SetRepeatModeAsync(ToRepeatState(newRepeatMode)));
         }
 
         private RepeatMode ToRepeatMode(RepeatState state)
@@ -294,7 +294,7 @@ namespace SpotifyAudioSource
                 case RepeatMode.RepeatTrack:
                     return RepeatState.Track;
                 default:
-                    Logger.Warn("No case for {mode}");
+                    Logger.Warn($"No case for {mode}");
                     return RepeatState.Off;
             }
         }
@@ -640,6 +640,15 @@ namespace SpotifyAudioSource
 
             var expiresIn = TimeSpan.FromSeconds(token.ExpiresIn);
             Logger.Debug($"Received new access token. Expires in: {expiresIn} (At {DateTime.Now + expiresIn})");
+        }
+
+        private async Task LogActionIfFailed(Func<Task<ErrorResponse>> action)
+        {
+            var result = await action();
+            if (result.HasError())
+            {
+                Logger.Warn($"Error performing action: Code = {result.Error.Status}, Message = {result.Error.Message}");
+            }
         }
     }
 }

--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Timers;
 using AudioBand.AudioSource;
@@ -249,22 +250,22 @@ namespace SpotifyAudioSource
 
         public async Task SetVolumeAsync(float newVolume)
         {
-            await LogActionIfFailed(() => _spotifyApi.SetVolumeAsync((int)(newVolume * 100)));
+            await LogPlayerCommandIfFailed(() => _spotifyApi.SetVolumeAsync((int)(newVolume * 100)));
         }
 
         public async Task SetPlaybackProgressAsync(TimeSpan newProgress)
         {
-            await LogActionIfFailed(() => _spotifyApi.SeekPlaybackAsync((int)newProgress.TotalMilliseconds));
+            await LogPlayerCommandIfFailed(() => _spotifyApi.SeekPlaybackAsync((int)newProgress.TotalMilliseconds));
         }
 
         public async Task SetShuffleAsync(bool shuffleOn)
         {
-            await LogActionIfFailed(() => _spotifyApi.SetShuffleAsync(shuffleOn));
+            await LogPlayerCommandIfFailed(() => _spotifyApi.SetShuffleAsync(shuffleOn));
         }
 
         public async Task SetRepeatModeAsync(RepeatMode newRepeatMode)
         {
-            await LogActionIfFailed(() => _spotifyApi.SetRepeatModeAsync(ToRepeatState(newRepeatMode)));
+            await LogPlayerCommandIfFailed(() => _spotifyApi.SetRepeatModeAsync(ToRepeatState(newRepeatMode)));
         }
 
         private RepeatMode ToRepeatMode(RepeatState state)
@@ -642,12 +643,12 @@ namespace SpotifyAudioSource
             Logger.Debug($"Received new access token. Expires in: {expiresIn} (At {DateTime.Now + expiresIn})");
         }
 
-        private async Task LogActionIfFailed(Func<Task<ErrorResponse>> action)
+        private async Task LogPlayerCommandIfFailed(Func<Task<ErrorResponse>> command, [CallerMemberName] string caller = null)
         {
-            var result = await action();
+            var result = await command();
             if (result.HasError())
             {
-                Logger.Warn($"Error performing action: Code = {result.Error.Status}, Message = {result.Error.Message}");
+                Logger.Warn($"Error with player command [{caller}]: Code = '{result.Error.Status}', Message = '{result.Error.Message}'");
             }
         }
     }


### PR DESCRIPTION
## Summary
Add checks to the response from Spotify player commands (e.g. shuffle, repeat)

## Checklist
- [x] Tests passed
- [x] Changes validated (manually or automated)
- [x] Closes / Fixes #224  (if applicable)

## Additional details / comments
I was ignoring the return value from the commands before and. The response contains errors if there are any so its important to log them.

## Manual test steps (if applicable)
Tested calls where the shuffle functionality is unavailable and confirmed that an error is logged.