### PR TITLE
Change auth/refresh logic of spotify tokens

### DIFF
--- a/src/SpotifyAudioSource/SpotifyAudioSource.cs
+++ b/src/SpotifyAudioSource/SpotifyAudioSource.cs
@@ -20,6 +20,9 @@ namespace SpotifyAudioSource
     /// </summary>
     public class SpotifyAudioSource : IAudioSource
     {
+        private const int MAXRETRIES = 20;
+        private const int RETRIESOFFSET = 30000;
+
         private readonly SpotifyControls _spotifyControls = new SpotifyControls();
         private readonly Timer _checkSpotifyTimer = new Timer(1000);
         private readonly ProxyConfig _proxyConfig = new ProxyConfig();
@@ -75,6 +78,11 @@ namespace SpotifyAudioSource
 
         /// <inheritdoc />
         public IAudioSourceLogger Logger { get; set; }
+
+        /// <summary>
+        /// Gets or sets current Retry attempt.
+        /// </summary>
+        public int CurrentRetries { get; set; } = 0;
 
         /// <summary>
         /// Gets or sets the spotify client id.
@@ -263,6 +271,7 @@ namespace SpotifyAudioSource
 
             _checkSpotifyTimer.Stop();
             _currentTrackId = null;
+            Logger.Debug("I have been deactivated.");
 
             return Task.CompletedTask;
         }
@@ -399,7 +408,14 @@ namespace SpotifyAudioSource
                 Logger.Debug("Authorization recieved");
 
                 var token = await _auth.ExchangeCode(payload.Code);
-                UpdateAccessToken(token);
+
+                if (!string.IsNullOrEmpty(token?.RefreshToken))
+                {
+                    RefreshToken = token.RefreshToken;
+                }
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                RefreshAccessToken();
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             }
             catch (Exception e)
             {
@@ -442,17 +458,40 @@ namespace SpotifyAudioSource
                     }
                 }
 
+                CurrentRetries = 0;
                 return playback;
             }
             catch (Exception e)
             {
                 Logger.Error(e);
 
+                HandleRetryAttempts();
+
                 // When there is an error, for unknown reasons, the client sometimes stops working properly
                 // i.e, it is unable to refresh the token properly. Recreate the client prevents this issue.
                 await Task.Delay(TimeSpan.FromSeconds(5));
                 _spotifyApi = CreateSpotifyClient(_spotifyApi.AccessToken, _spotifyApi.TokenType);
                 return null;
+            }
+        }
+
+        private void HandleRetryAttempts(bool refreshTokenRetry = false)
+        {
+            CurrentRetries++;
+            var newInterval = RETRIESOFFSET * CurrentRetries;
+            _checkSpotifyTimer.Interval = newInterval;
+            Logger.Debug($"Retry {CurrentRetries}/{MAXRETRIES}. Increasing polling interval to: {_checkSpotifyTimer.Interval}ms");
+
+            if (CurrentRetries >= MAXRETRIES)
+            {
+                Logger.Warn("Maximum retries reached.");
+                if (refreshTokenRetry)
+                {
+                    Logger.Warn($"Resetting {nameof(RefreshToken)}. Go through Authorization flow again to get a new token.");
+                    RefreshToken = null;
+                }
+
+                DeactivateAsync();
             }
         }
 
@@ -645,16 +684,32 @@ namespace SpotifyAudioSource
 
         private async Task RefreshAccessToken()
         {
+            if (string.IsNullOrWhiteSpace(RefreshToken))
+            {
+                Logger.Warn("RefreshToken missing. Please restart and go through the authorization process again.");
+                await DeactivateAsync();
+                return;
+            }
+
             try
             {
                 Logger.Debug("Getting new access token");
 
                 var token = await _auth.RefreshToken(RefreshToken);
+
                 if (token.HasError())
                 {
-                    Logger.Warn($"Error getting new token. Requesting new refresh token. Error: {token.Error}|{token.ErrorDescription}");
-                    RefreshToken = null;
-                    Authorize();
+                    Logger.Warn($"Error getting new Access token. Error: {token.Error}|{token.ErrorDescription}");
+
+                    if (token.Error.Equals("invalid_grant"))
+                    {
+                        Logger.Error("RefreshToken is revoked or wrong. Restart and go through the authorization process again.");
+                        RefreshToken = null;
+                        await DeactivateAsync();
+                        return;
+                    }
+
+                    HandleRetryAttempts(true);
                     return;
                 }
 
@@ -685,11 +740,6 @@ namespace SpotifyAudioSource
             }
 
             _spotifyApi = CreateSpotifyClient(token.AccessToken, token.TokenType);
-
-            if (!string.IsNullOrEmpty(token.RefreshToken))
-            {
-                RefreshToken = token.RefreshToken;
-            }
 
             var expiresIn = TimeSpan.FromSeconds(token.ExpiresIn);
             Logger.Debug($"Received new access token. Expires in: {expiresIn} (At {DateTime.Now + expiresIn})");


### PR DESCRIPTION
Fixes #241 

Removed infinite loop when a refreshToken has expired or been revoked. If token has been revoked we will now discard the token and Spotify will be deactivated as an audiosource and a message about the revoked token will display in the log. 
We will also never try and refresh an AccessToken with an Empty RefreshToken anymore, since that would never work anyway.

Added retries if Refreshing the access token fails for any other reason. If we reach maximum retries the RefreshToken will be considered bad and we will discard it, user will have to go through the Authorization process again.

Added retries for polling fails. If internet connection goes out for example, we will retry 20 times with increasing time between tries. What happened before was that the log was spammed every second with big error messages. If we reach maximum retries Spotify audosource will be disabled until reload.

## Summary

## Checklist
- [x ] Tests passed
- [ x] Changes validated (manually or automated)
- [#241 ] Closes / Fixes #xxx (if applicable)

## Additional details / comments
Authorize should really only be needed once. The RefreshToken should have a long lifetime (forever?) if it's not revoked.
So even better would be to introduce a "connect" button for Spotify in the settings where all authorization is done. Then we would just use refreshing during normal operations, but some sort of message would need to be displayed if/when the refreshtoken becomes invalid/revoked. But this should work for now.

## Manual test steps (if applicable)