### PR TITLE
Added missing step

### DIFF
--- a/docfx/audioband/audiosources/spotify.md
+++ b/docfx/audioband/audiosources/spotify.md
@@ -7,7 +7,8 @@
 3. Right click anywhere in the toolbar > Audio Band Settings > Audio Source Settings and fill in the fields `Spotify Client Id` and `Spotify Client Secret`. You can find them in the same dashboard page for the Spotify app you created.
     1. You can also change the `Callback Port` if needed.
 4. Your browser should open asking you to login and allow your spotify app to access your currently playing songs.
-5. Sign-in and accept and it should now display song information (make sure spotify is selected as the audio source).
+    1. If your browser does not open automatically, Right click the toolbar and select Audio Sources > Spotify. It should now open in your default browser. 
+6. Sign-in and accept and it should now display song information (make sure spotify is selected as the audio source).
 
 >[!NOTE]
 > Currently you need to have the Spotify desktop application for the playback buttons to work properly.


### PR DESCRIPTION
The webpage for connecting to spotify doesnt automatically load under certain circumstances (Spotify not selected). Selecting Spofity as an audio source will force it to open.

## Summary

## Checklist
- [ ] Tests passed
- [ ] Changes validated (manually or automated)
- [ ] Closes / Fixes #xxx (if applicable)

## Additional details / comments

## Manual test steps (if applicable)